### PR TITLE
moving risk_data function to a new file and tests for Escribir_Datos_Osiris

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY Pipfile Pipfile.lock ./
 
 RUN pipenv install --system --deploy --ignore-pipfile
 
+ENV file_directory="Subida Osiris"
+
 COPY . .
 
 CMD ["python3", "src/subida.py"]

--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,13 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pytest = "7.2.2"
 pandas = "2.0.0"
 numpy = "1.24.2"
-ipdb = "0.13.13"
 
 [dev-packages]
+pytest = "7.2.2"
+ipdb = "0.13.13"
+freezegun = "1.2.2"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "94c27d8e2b4bcbb9fa179f4beeb3ef364028250cc811d38d100fa07aa2138575"
+            "sha256": "8734b3891103edbccd7c586d8ba3bace1c7ce79a7b8e9f82e9be54a782402627"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,104 @@
         ]
     },
     "default": {
+        "numpy": {
+            "hashes": [
+                "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22",
+                "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f",
+                "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9",
+                "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96",
+                "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0",
+                "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a",
+                "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281",
+                "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04",
+                "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468",
+                "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253",
+                "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756",
+                "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a",
+                "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb",
+                "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d",
+                "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0",
+                "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910",
+                "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978",
+                "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5",
+                "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f",
+                "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a",
+                "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5",
+                "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2",
+                "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d",
+                "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95",
+                "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5",
+                "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d",
+                "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780",
+                "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"
+            ],
+            "index": "pypi",
+            "version": "==1.24.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:0778ab54c8f399d83d98ffb674d11ec716449956bc6f6821891ab835848687f2",
+                "sha256:24472cfc7ced511ac90608728b88312be56edc8f19b9ed885a7d2e47ffaf69c0",
+                "sha256:2d1d138848dd71b37e3cbe7cd952ff84e2ab04d8988972166e18567dcc811245",
+                "sha256:3bb9d840bf15656805f6a3d87eea9dcb7efdf1314a82adcf7f00b820427c5570",
+                "sha256:425705cee8be54db2504e8dd2a730684790b15e5904b750c367611ede49098ab",
+                "sha256:4f3320bb55f34af4193020158ef8118ee0fb9aec7cc47d2084dbfdd868a0a24f",
+                "sha256:4ffb14f50c74ee541610668137830bb93e9dfa319b1bef2cedf2814cd5ac9c70",
+                "sha256:52c858de9e9fc422d25e67e1592a6e6135d7bcf9a19fcaf4d0831a0be496bf21",
+                "sha256:57c34b79c13249505e850d0377b722961b99140f81dafbe6f19ef10239f6284a",
+                "sha256:6ded51f7e3dd9b4f8b87f2ceb7bd1a8df2491f7ee72f7074c6927a512607199e",
+                "sha256:70db5c278bbec0306d32bf78751ff56b9594c05a5098386f6c8a563659124f91",
+                "sha256:78425ca12314b23356c28b16765639db10ebb7d8983f705d6759ff7fe41357fa",
+                "sha256:8318de0f886e4dcb8f9f36e45a3d6a6c3d1cfdc508354da85e739090f0222991",
+                "sha256:8f987ec26e96a8490909bc5d98c514147236e49830cba7df8690f6087c12bbae",
+                "sha256:9253edfd015520ce77a9343eb7097429479c039cd3ebe81d7810ea11b4b24695",
+                "sha256:977326039bd1ded620001a1889e2ed4798460a6bc5a24fbaebb5f07a41c32a55",
+                "sha256:a4f789b7c012a608c08cda4ff0872fd979cb18907a37982abe884e6f529b8793",
+                "sha256:b3ba8f5dd470d8bfbc4259829589f4a32881151c49e36384d9eb982b35a12020",
+                "sha256:b5337c87c4e963f97becb1217965b6b75c6fe5f54c4cf09b9a5ac52fc0bd03d3",
+                "sha256:bbb2c5e94d6aa4e632646a3bacd05c2a871c3aa3e85c9bec9be99cb1267279f2",
+                "sha256:c24c7d12d033a372a9daf9ff2c80f8b0af6f98d14664dbb0a4f6a029094928a7",
+                "sha256:cda9789e61b44463c1c4fe17ef755de77bcd13b09ba31c940d20f193d63a5dc8",
+                "sha256:d08e41d96bc4de6f500afe80936c68fce6099d5a434e2af7c7fd8e7c72a3265d",
+                "sha256:d93b7fcfd9f3328072b250d6d001dcfeec5d3bb66c1b9c8941e109a46c0c01a8",
+                "sha256:fcd471c9d9f60926ab2f15c6c29164112f458acb42280365fbefa542d0c2fc74"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
+                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
+            ],
+            "version": "==2023.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
+                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+            ],
+            "markers": "python_version >= '2'",
+            "version": "==2023.3"
+        }
+    },
+    "develop": {
         "appnope": {
             "hashes": [
                 "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
@@ -30,14 +128,6 @@
                 "sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c"
             ],
             "version": "==2.2.1"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
         },
         "backcall": {
             "hashes": [
@@ -68,6 +158,14 @@
                 "sha256:19da64c18d2d851112f09c287f8d3dbbdf725ab0e569077efb6cdcbd3497c107"
             ],
             "version": "==1.2.0"
+        },
+        "freezegun": {
+            "hashes": [
+                "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446",
+                "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"
+            ],
+            "index": "pypi",
+            "version": "==1.2.2"
         },
         "iniconfig": {
             "hashes": [
@@ -109,40 +207,6 @@
             "markers": "python_version >= '3.5'",
             "version": "==0.1.6"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22",
-                "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f",
-                "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9",
-                "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96",
-                "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0",
-                "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a",
-                "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281",
-                "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04",
-                "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468",
-                "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253",
-                "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756",
-                "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a",
-                "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb",
-                "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d",
-                "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0",
-                "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910",
-                "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978",
-                "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5",
-                "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f",
-                "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a",
-                "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5",
-                "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2",
-                "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d",
-                "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95",
-                "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5",
-                "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d",
-                "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780",
-                "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"
-            ],
-            "index": "pypi",
-            "version": "==1.24.2"
-        },
         "packaging": {
             "hashes": [
                 "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
@@ -150,37 +214,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==23.0"
-        },
-        "pandas": {
-            "hashes": [
-                "sha256:0778ab54c8f399d83d98ffb674d11ec716449956bc6f6821891ab835848687f2",
-                "sha256:24472cfc7ced511ac90608728b88312be56edc8f19b9ed885a7d2e47ffaf69c0",
-                "sha256:2d1d138848dd71b37e3cbe7cd952ff84e2ab04d8988972166e18567dcc811245",
-                "sha256:3bb9d840bf15656805f6a3d87eea9dcb7efdf1314a82adcf7f00b820427c5570",
-                "sha256:425705cee8be54db2504e8dd2a730684790b15e5904b750c367611ede49098ab",
-                "sha256:4f3320bb55f34af4193020158ef8118ee0fb9aec7cc47d2084dbfdd868a0a24f",
-                "sha256:4ffb14f50c74ee541610668137830bb93e9dfa319b1bef2cedf2814cd5ac9c70",
-                "sha256:52c858de9e9fc422d25e67e1592a6e6135d7bcf9a19fcaf4d0831a0be496bf21",
-                "sha256:57c34b79c13249505e850d0377b722961b99140f81dafbe6f19ef10239f6284a",
-                "sha256:6ded51f7e3dd9b4f8b87f2ceb7bd1a8df2491f7ee72f7074c6927a512607199e",
-                "sha256:70db5c278bbec0306d32bf78751ff56b9594c05a5098386f6c8a563659124f91",
-                "sha256:78425ca12314b23356c28b16765639db10ebb7d8983f705d6759ff7fe41357fa",
-                "sha256:8318de0f886e4dcb8f9f36e45a3d6a6c3d1cfdc508354da85e739090f0222991",
-                "sha256:8f987ec26e96a8490909bc5d98c514147236e49830cba7df8690f6087c12bbae",
-                "sha256:9253edfd015520ce77a9343eb7097429479c039cd3ebe81d7810ea11b4b24695",
-                "sha256:977326039bd1ded620001a1889e2ed4798460a6bc5a24fbaebb5f07a41c32a55",
-                "sha256:a4f789b7c012a608c08cda4ff0872fd979cb18907a37982abe884e6f529b8793",
-                "sha256:b3ba8f5dd470d8bfbc4259829589f4a32881151c49e36384d9eb982b35a12020",
-                "sha256:b5337c87c4e963f97becb1217965b6b75c6fe5f54c4cf09b9a5ac52fc0bd03d3",
-                "sha256:bbb2c5e94d6aa4e632646a3bacd05c2a871c3aa3e85c9bec9be99cb1267279f2",
-                "sha256:c24c7d12d033a372a9daf9ff2c80f8b0af6f98d14664dbb0a4f6a029094928a7",
-                "sha256:cda9789e61b44463c1c4fe17ef755de77bcd13b09ba31c940d20f193d63a5dc8",
-                "sha256:d08e41d96bc4de6f500afe80936c68fce6099d5a434e2af7c7fd8e7c72a3265d",
-                "sha256:d93b7fcfd9f3328072b250d6d001dcfeec5d3bb66c1b9c8941e109a46c0c01a8",
-                "sha256:fcd471c9d9f60926ab2f15c6c29164112f458acb42280365fbefa542d0c2fc74"
-            ],
-            "index": "pypi",
-            "version": "==2.0.0"
         },
         "parso": {
             "hashes": [
@@ -237,19 +270,19 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
-                "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"
+                "sha256:77a3299119af881904cd5ecd1ac6a66214b6e9bed1f2db16993b54adede64094",
+                "sha256:f7e36cffc4c517fbc252861b9a6e4644ca0e5abadf9a113c72d1358ad09b9500"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.14.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.15.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e",
-                "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"
+                "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d",
+                "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"
             ],
             "index": "pypi",
-            "version": "==7.2.2"
+            "version": "==7.3.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -258,13 +291,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
-                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
-            ],
-            "version": "==2023.3"
         },
         "six": {
             "hashes": [
@@ -297,14 +323,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==5.9.0"
         },
-        "tzdata": {
-            "hashes": [
-                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
-                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
-            ],
-            "markers": "python_version >= '2'",
-            "version": "==2023.3"
-        },
         "wcwidth": {
             "hashes": [
                 "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
@@ -312,6 +330,5 @@
             ],
             "version": "==0.2.6"
         }
-    },
-    "develop": {}
+    }
 }

--- a/src/risk_data.py
+++ b/src/risk_data.py
@@ -1,0 +1,64 @@
+import pandas as pd
+from constants.constants import NUMBER_OF_COLUMNS
+from write_data_osiris import Escribir_Datos_Osiris
+
+
+def get_phone_risk(df_risk: pd.DataFrame) -> pd.DataFrame:
+    frames = list()
+    num_tel = len([col_name for col_name in list(df_risk.columns) if 'tel_riesgo' in col_name])
+    for i in range(1, num_tel + 1):
+        col_riesgo = f'tel_riesgo_{i}'
+        df = df_risk.loc[df_risk[col_riesgo].notnull(), ['Cuenta', col_riesgo]]\
+            .rename(columns={col_riesgo: 'TEL'}).copy()
+        df['OBS'] = f'RIESGO {i}'
+        df['ID_FONO'] = '8'
+        frames.append(df)
+    df_phone_risk = pd.concat(frames)
+    return df_phone_risk
+
+
+def read_osiris_accounts() -> pd.DataFrame:
+    try:
+        uploaded_accounts = pd.read_csv('cuentas.csv', encoding='latin_1', sep=';', dtype=str)
+    except Exception:
+        uploaded_accounts = pd.read_csv('cuentas.csv', encoding='ANSI', sep=';', dtype=str)
+    uploaded_accounts = uploaded_accounts[['Cuenta', 'Mat. Unica']].rename(
+        columns={
+            'Mat. Unica': 'DNI'
+            },
+        inplace=False
+        )
+    return uploaded_accounts
+
+
+def risk_data():
+    'NECESARIOS: tener el archivos.csv de riesgo y el archivo de las cuentas de osiris como cuentas.csv'
+    col_numbers = {
+        'NÃºmero.1': 'tel_riesgo_1',
+        'NÃºmero.2': 'tel_riesgo_2',
+        'NÃºmero.3': 'tel_riesgo_3',
+        'NÃºmero.4': 'tel_riesgo_4'
+    }
+
+    col_list = [x for x in range(NUMBER_OF_COLUMNS)]
+    try:
+        risk = pd.read_csv('riesgo.csv', sep=';', encoding='latin_1', dtype=str, index_col=False, usecols=col_list)
+    except Exception:
+        risk = pd.read_csv('riesgo.csv', sep=';', encoding='ANSI', dtype=str, index_col=False, usecols=col_list)
+    df_risk = risk[['DNI'] + list(col_numbers.keys()) + ['NSE']]
+
+    df_risk = df_risk.rename(columns=col_numbers, inplace=False)
+
+    uploaded_accounts = read_osiris_accounts()
+
+    df_risk = pd.merge(uploaded_accounts, df_risk, how="inner", on="DNI")
+
+    df_phone_risk = get_phone_risk(df_risk=df_risk)
+
+    Escribir_Datos_Osiris(
+        df_phone_risk,
+        'RIESGO_telefonos.csv',
+        ['Cuenta', 'ID_FONO', 'TEL', 'OBS'],
+        ["ID Cuenta o Nro. de Asig. (0)", "ID Tipo de Teléfono (17)", "Nro. de Teléfono (18)", "Obs. de Teléfono (19)"]
+    )
+    print('Planilla de Teléfonos de RIESGO escrita')

--- a/src/subida.py
+++ b/src/subida.py
@@ -3,8 +3,7 @@ import os
 import shutil
 import pandas as pd
 import numpy as np
-import datetime
-import time
+from datetime import datetime
 import traceback
 
 from driver_email import enviar_mail_con_adjuntos
@@ -113,14 +112,14 @@ def Preparacion_Cuentas():
         df_sub = df_sub.drop('riesgo', inplace=False, axis=1)
         try:
             df_sub.to_csv(
-                f'Subida Osiris/{time.strftime("(%H.%M hs) -")} subida_cartera_{name}.csv',
+                f'Subida Osiris/{datetime.now().strftime("(%H.%M hs) -")} subida_cartera_{name}.csv',
                 sep=';',
                 encoding='latin_1',
                 index=False
             )
         except Exception:
             df_sub.to_csv(
-                f'Subida Osiris/{time.strftime("(%H.%M hs) -")} subida_cartera_{name}.csv',
+                f'Subida Osiris/{datetime.now().strftime("(%H.%M hs) -")} subida_cartera_{name}.csv',
                 sep=';',
                 encoding='ANSI',
                 index=False
@@ -185,7 +184,7 @@ def Preparacion_Cuentas_Comafi():
     df_os['IDSucursal(17)'] = '1'
     df_os['subcliente'] = df['subcliente']
 
-    name_folder = f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {nombre_cartera}'
+    name_folder = f'Subida Osiris/{datetime.now().strftime("(%H.%M hs) -")} {nombre_cartera}'
     if os.path.isdir(name_folder):
         shutil.rmtree(name_folder)
     os.mkdir(name_folder)
@@ -332,14 +331,14 @@ def Preparacion_Datos_Comafi():
     print('Guardando planilla subida...')
     try:
         df_subida.to_csv(
-            f'Subida Osiris/{time.strftime("(%H.%M hs) -")}DATOS_EMERIX_subida_telefono.csv',
+            f'Subida Osiris/{datetime.now().strftime("(%H.%M hs) -")}DATOS_EMERIX_subida_telefono.csv',
             sep=';',
             index=False,
             encoding='ANSI'
         )
     except Exception:
         df_subida.to_csv(
-            f'Subida Osiris/{time.strftime("(%H.%M hs) -")}DATOS_EMERIX_subida_telefono.csv',
+            f'Subida Osiris/{datetime.now().strftime("(%H.%M hs) -")}DATOS_EMERIX_subida_telefono.csv',
             sep=';',
             index=False,
             encoding='ANSI'

--- a/src/subida.py
+++ b/src/subida.py
@@ -12,15 +12,15 @@ from constants.constants import (
     PROGRAMMER,
     USER,
     PASSWORD,
-    DATA_UPLOADER_HEADER,
     PROVINCES,
     UTIL_COLS_COMAFI,
     ACCOUNT_PREP_COL,
-    NUMBER_OF_COLUMNS,
     DATA_PREP_COLUMNS,
     DATA_INFO_COLUMNS,
     DATA_INFO_COLUMNS_RENAME,
 )
+from risk_data import risk_data
+from write_data_osiris import Escribir_Datos_Osiris
 
 
 def limpiar_numeros(df_num):
@@ -59,34 +59,6 @@ def limpiar_numeros(df_num):
             .str.replace(r'^[54]+', '', regex=True).str.replace(r'^[0] + ', '', regex=True)
 
     return df_num
-
-
-def Escribir_Datos_Osiris(df, filename, cols_df, cols_osiris):
-
-    Control_Carpeta_Subida()
-
-    df_subida = pd.DataFrame(columns=DATA_UPLOADER_HEADER)
-    df_subida[cols_osiris] = df[cols_df]
-    try:
-        df_subida.to_csv(
-            f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {filename}',
-            sep=';',
-            index=False,
-            encoding='latin_1'
-        )
-    except Exception:
-        df_subida.to_csv(
-            f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {filename}',
-            sep=';',
-            index=False,
-            encoding='ANSI'
-        )
-
-
-def Control_Carpeta_Subida():
-    'COntrola que exista una carpeta llamada Subida Osiris y sino la crea'
-    pass
-    # no la estoy usando
 
 
 def Preparacion_Cuentas():
@@ -373,67 +345,6 @@ def Preparacion_Datos_Comafi():
             encoding='ANSI'
         )
     print('Guardado exitoso!')
-
-
-def get_phone_risk(df_risk: pd.DataFrame) -> pd.DataFrame:
-    frames = list()
-    num_tel = len([col_name for col_name in list(df_risk.columns) if 'tel_riesgo' in col_name])
-    for i in range(1, num_tel + 1):
-        col_riesgo = f'tel_riesgo_{i}'
-        df = df_risk.loc[df_risk[col_riesgo].notnull(), ['Cuenta', col_riesgo]]\
-            .rename(columns={col_riesgo: 'TEL'}).copy()
-        df['OBS'] = f'RIESGO {i}'
-        df['ID_FONO'] = '8'
-        frames.append(df)
-    df_phone_risk = pd.concat(frames)
-    return df_phone_risk
-
-
-def read_osiris_accounts() -> pd.DataFrame:
-    try:
-        uploaded_accounts = pd.read_csv('cuentas.csv', encoding='latin_1', sep=';', dtype=str)
-    except Exception:
-        uploaded_accounts = pd.read_csv('cuentas.csv', encoding='ANSI', sep=';', dtype=str)
-    uploaded_accounts = uploaded_accounts[['Cuenta', 'Mat. Unica']].rename(
-        columns={
-            'Mat. Unica': 'DNI'
-            },
-        inplace=False
-        )
-    return uploaded_accounts
-
-
-def risk_data():
-    'NECESARIOS: tener el archivos.csv de riesgo y el archivo de las cuentas de osiris como cuentas.csv'
-    col_numbers = {
-        'NÃºmero.1': 'tel_riesgo_1',
-        'NÃºmero.2': 'tel_riesgo_2',
-        'NÃºmero.3': 'tel_riesgo_3',
-        'NÃºmero.4': 'tel_riesgo_4'
-    }
-
-    col_list = [x for x in range(NUMBER_OF_COLUMNS)]
-    try:
-        risk = pd.read_csv('riesgo.csv', sep=';', encoding='latin_1', dtype=str, index_col=False, usecols=col_list)
-    except Exception:
-        risk = pd.read_csv('riesgo.csv', sep=';', encoding='ANSI', dtype=str, index_col=False, usecols=col_list)
-    df_risk = risk[['DNI'] + list(col_numbers.keys()) + ['NSE']]
-
-    df_risk = df_risk.rename(columns=col_numbers, inplace=False)
-
-    uploaded_accounts = read_osiris_accounts()
-
-    df_risk = pd.merge(uploaded_accounts, df_risk, how="inner", on="DNI")
-
-    df_phone_risk = get_phone_risk(df_risk=df_risk)
-
-    Escribir_Datos_Osiris(
-        df_phone_risk,
-        'RIESGO_telefonos.csv',
-        ['Cuenta', 'ID_FONO', 'TEL', 'OBS'],
-        ["ID Cuenta o Nro. de Asig. (0)", "ID Tipo de Teléfono (17)", "Nro. de Teléfono (18)", "Obs. de Teléfono (19)"]
-    )
-    print('Planilla de Teléfonos de RIESGO escrita')
 
 
 def Datos_Info():

--- a/src/write_data_osiris.py
+++ b/src/write_data_osiris.py
@@ -1,0 +1,32 @@
+
+import pandas as pd
+import time
+from constants.constants import DATA_UPLOADER_HEADER
+
+
+def Escribir_Datos_Osiris(df, filename, cols_df, cols_osiris):
+
+    Control_Carpeta_Subida()
+
+    df_subida = pd.DataFrame(columns=DATA_UPLOADER_HEADER)
+    df_subida[cols_osiris] = df[cols_df]
+    try:
+        df_subida.to_csv(
+            f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {filename}',
+            sep=';',
+            index=False,
+            encoding='latin_1'
+        )
+    except Exception:
+        df_subida.to_csv(
+            f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {filename}',
+            sep=';',
+            index=False,
+            encoding='ANSI'
+        )
+
+
+def Control_Carpeta_Subida():
+    'COntrola que exista una carpeta llamada Subida Osiris y sino la crea'
+    pass
+    # no la estoy usando

--- a/src/write_data_osiris.py
+++ b/src/write_data_osiris.py
@@ -1,10 +1,11 @@
 
+from datetime import datetime
+import os
 import pandas as pd
-import time
 from constants.constants import DATA_UPLOADER_HEADER
 
 
-def Escribir_Datos_Osiris(df, filename, cols_df, cols_osiris):
+def Escribir_Datos_Osiris(df: pd.DataFrame, filename: str, cols_df: list[str], cols_osiris: list[str]):
 
     Control_Carpeta_Subida()
 
@@ -12,14 +13,15 @@ def Escribir_Datos_Osiris(df, filename, cols_df, cols_osiris):
     df_subida[cols_osiris] = df[cols_df]
     try:
         df_subida.to_csv(
-            f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {filename}',
+            f'{os.getenv("file_directory", "Subida Osiris")}/{datetime.now().strftime("(%H.%M hs) -")} {filename}',
             sep=';',
             index=False,
             encoding='latin_1'
         )
+
     except Exception:
         df_subida.to_csv(
-            f'Subida Osiris/{time.strftime("(%H.%M hs) -")} {filename}',
+            f'{os.getenv("file_directory", "Subida Osiris")}/{datetime.now().strftime("(%H.%M hs) -")} {filename}',
             sep=';',
             index=False,
             encoding='ANSI'

--- a/tests/test_risk_data.py
+++ b/tests/test_risk_data.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from src.subida import (
+from src.risk_data import (
     get_phone_risk,
     read_osiris_accounts,
     risk_data
@@ -51,9 +51,9 @@ class TestRiskData:
 
     @mock.patch("pandas.read_csv")
     @mock.patch("pandas.merge")
-    @mock.patch("src.subida.read_osiris_accounts")
-    @mock.patch("src.subida.get_phone_risk")
-    @mock.patch("src.subida.Escribir_Datos_Osiris")
+    @mock.patch("src.risk_data.read_osiris_accounts")
+    @mock.patch("src.risk_data.get_phone_risk")
+    @mock.patch("src.risk_data.Escribir_Datos_Osiris")
     def test_risk_data(
         self,
         mock_Escribir_Datos_Osiris,

--- a/tests/test_write_data_osiris.py
+++ b/tests/test_write_data_osiris.py
@@ -1,0 +1,95 @@
+from freezegun import freeze_time
+import pandas as pd
+import pytest
+import tempfile
+from unittest import mock
+from src.write_data_osiris import Escribir_Datos_Osiris
+
+
+@pytest.mark.parametrize("mock_df, mock_filename, mock_cols_df, mock_cols_osiris", [
+        (
+            pd.DataFrame(
+                    {
+                        "Cuenta": "3333",
+                        "TEL": '123455678',
+                        "OBS": "RIESGO 1",
+                        "ID_FONO": "8",
+                    },
+                    index=[0]
+                ),
+            'RIESGO_telefonos.csv',
+            ['Cuenta', 'ID_FONO', 'TEL', 'OBS'],
+            [
+                "ID Cuenta o Nro. de Asig. (0)",
+                "ID Tipo de Teléfono (17)",
+                "Nro. de Teléfono (18)",
+                "Obs. de Teléfono (19)"
+            ]
+        )
+    ]
+)
+class TestWriteDataOsiris:
+
+    @mock.patch('src.write_data_osiris.os.getenv')
+    def test_create_file_in_existing_folder_get_by_env_variable(
+        self,
+        mock_get_env,
+        mock_df,
+        mock_filename,
+        mock_cols_df,
+        mock_cols_osiris,
+    ):
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            mock_get_env.return_value = tmpdirname
+            Escribir_Datos_Osiris(
+                df=mock_df,
+                filename=mock_filename,
+                cols_df=mock_cols_df,
+                cols_osiris=mock_cols_osiris,
+            )
+
+    @freeze_time("2023-04-08 18:45:00")
+    @mock.patch.object(pd.DataFrame, 'to_csv')
+    def test_create_file_in_existing_folder_without_env_variable(
+        self,
+        mock_to_csv,
+        mock_df,
+        mock_filename,
+        mock_cols_df,
+        mock_cols_osiris,
+    ):
+
+        Escribir_Datos_Osiris(
+            df=mock_df,
+            filename=mock_filename,
+            cols_df=mock_cols_df,
+            cols_osiris=mock_cols_osiris,
+        )
+
+        mock_to_csv.assert_called_once()
+        mock_to_csv.assert_called_once_with(
+            f'{"Subida Osiris"}/(18.45 hs) - {mock_filename}',
+            sep=';',
+            index=False,
+            encoding='latin_1'
+        )
+
+    @mock.patch('src.write_data_osiris.os.getenv')
+    def test_raise_exception_folder_doesnt_exist(
+        self,
+        mock_get_env,
+        mock_df,
+        mock_filename,
+        mock_cols_df,
+        mock_cols_osiris,
+    ):
+
+        with pytest.raises(Exception):
+            mock_get_env.return_value = "Another folder"
+            Escribir_Datos_Osiris(
+                df=mock_df,
+                filename=mock_filename,
+                cols_df=mock_cols_df,
+                cols_osiris=mock_cols_osiris,
+            )


### PR DESCRIPTION
- moving `risk_data` function and its helper function to a new file 
- moving `Escribir_Datos_Osiris` to a new file to avoid circular import between `risk_data.py`  and `subida.py`
- renamed the test file created in previous PR from `test_get_phone_numbers.py` to `test_risk_data.py`
- adding tests for `Escribir_Datos_Osiris()`
- replacing `time` for `datetime` library, because when I use the `freezegun` to test the time the file is created, there was an error with this library using time ([issue from freezgun repo](https://github.com/spulec/freezegun/issues/494)). 
- adding an environment variable in `Dockerfile`: `file_directory="Subida Osiris"` , if the script doesn't find this variable, uses the default value "Subida Osiris" --> this is archive with: `os.getenv("file_directory", "Subida Osiris") `
- moving `ipdb`, `pytest` dependencies in Pipfile to `[dev-packages]` and adding `freezegun` to it


## Documentation:
[freezegun](https://github.com/spulec/freezegun) --> FreezeGun is a library that allows your Python tests to travel through time by mocking the datetime module.
[tempfile.TemporaryDirectory](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory) --> This class securely creates a temporary directory. I used it to create a folder and test `Escribir_Datos_Osiris`, otherwise raises an Exception if there is no folder created. 