### PR TITLE
Fix: datetime.date and annotation from PR #8

### DIFF
--- a/src/subida.py
+++ b/src/subida.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import pandas as pd
 import numpy as np
-from datetime import datetime
+from datetime import datetime, date
 import traceback
 
 from driver_email import enviar_mail_con_adjuntos
@@ -74,7 +74,7 @@ def Preparacion_Cuentas():
 
     provincias = PROVINCES
 
-    date_now = datetime.date.today()
+    date_now = date.today()
     years_to_add = date_now.year + 3
 
     date_1 = date_now.strftime('%d/%m/%Y')
@@ -155,7 +155,7 @@ def Preparacion_Cuentas_Comafi():
     print('\n')
     print('\nComenzando escritura de archivos..\n\n')
 
-    date_now = datetime.date.today()
+    date_now = date.today()
     years_to_add = date_now.year + 3
 
     date_1 = date_now.strftime('%d/%m/%Y')

--- a/src/write_data_osiris.py
+++ b/src/write_data_osiris.py
@@ -5,7 +5,7 @@ import pandas as pd
 from constants.constants import DATA_UPLOADER_HEADER
 
 
-def Escribir_Datos_Osiris(df: pd.DataFrame, filename: str, cols_df: list[str], cols_osiris: list[str]):
+def Escribir_Datos_Osiris(df: pd.DataFrame, filename: str, cols_df: 'list[str]', cols_osiris: 'list[str]'):
 
     Control_Carpeta_Subida()
 


### PR DESCRIPTION
changing the import to from, make error running the app because date was used from the namespace datetime, y change the import and the annotation werent't wrapped with simple commas `'` so python interpretates this as we are trying to index a list class objetct