### PR TITLE
Use PreventUpdate to avoid updating the callback output

### DIFF
--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -1,6 +1,7 @@
 from app import app
 from dash import Output, Input, State, html, dcc, MATCH, ctx
 import base64
+from dash.exceptions import PreventUpdate
 from src.adapters.dash_dataframe_saver import DashDataFrameSaver
 from callbacks_helpers import process_naranja_client, process_comafi_client
 
@@ -27,7 +28,7 @@ def upload_csv(list_of_contents, client_selected):
         return download_buttons, data_dict
 
     else:
-        return html.Div(), None
+        raise PreventUpdate
 
 
 @app.callback(
@@ -39,7 +40,7 @@ def upload_csv(list_of_contents, client_selected):
 )
 def download_csv(n_clicks, dfs):
     if not n_clicks:
-        return
+        raise PreventUpdate
     df_id = ctx.triggered_id["id"]
     df = dfs[df_id]
     return dcc.send_string(df, f"{df_id}.csv")


### PR DESCRIPTION
As Mati suggest in another PR: https://github.com/alquimistas-org/subida_cartera/pull/24#discussion_r1189744133
- Using PreventUpdate in upload_csv callback
- Using PreventUpdate in download_csv callback

### Documentation
[PreventUpdate](https://dash.plotly.com/advanced-callbacks#catching-errors-with-preventupdate)