### PR TITLE
Refresh data button

### DIFF
--- a/web-app/assets/style.css
+++ b/web-app/assets/style.css
@@ -22,8 +22,12 @@ span.jsx-3468109796 {
     margin-top: 2rem;
     height: 350px;
 }
+.selec-client{
+    margin-top: 2rem;
+    margin-bottom: 0;
+}
 
-.attach-file{
+.attach-file, .selec-client{
     font-size: x-large;
     margin-left: 0.5rem;
 }
@@ -142,10 +146,51 @@ a.upload-link-container{
     width: 100%;
 }
 
+.btn-tab:hover{
+    cursor: pointer;
+    border-color:  #29a9e0;
+    color: #29a9e0;
+}
+
 .fa-trash-can{
     color:red;
+    font-size: x-large;
 }
-.fa-trash-can:hover{
+
+.clear-data-icon-span-container:hover{
     cursor: pointer;
     color: rgb(245, 97, 97);
+}
+
+.clear-data-container{
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+}
+
+.clean-data-text{
+    font-size: large;
+    font-weight: 400;
+}
+
+.modal-content{
+    border-radius: 10px;
+    text-align: center;
+    font-weight: 500;
+}
+
+.modal-footer{
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: center;
+}
+
+.mr-auto, .btn-primary{
+    background-color: #1d8ab6;
+    border-color: #1d8ab6;
+}
+
+.btn-danger{
+    background-color: red;
+    border-color: red;
 }

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -54,8 +54,8 @@ def download_csv(n_clicks, dfs):
 )
 def collapse_upload(filaname, is_open):
     return not is_open, html.Div([
-        filaname,
-        html.I(className="fa-regular fa-trash-can", id="delete-cr", style={'marginLeft': '1rem'})])
+        filaname
+    ])
 
 
 @app.callback(
@@ -69,21 +69,43 @@ def collapse_upload(filaname, is_open):
 def get_client(btn_1, btn_2):
     client_id = ctx.triggered_id
 
-    white_button_style = {
+    not_selected_button_style = {
         'background-color': 'white'
     }
 
-    red_button_style = {
+    selected_client_style = {
         'background-color': '#1d8ab6',
         'border-color': '#1d8ab6',
         'color': 'white',
      }
 
     if client_id == 'naranja':
-        style_naranja = red_button_style
-        style_comafi = white_button_style
+        style_naranja = selected_client_style
+        style_comafi = not_selected_button_style
     elif client_id == 'comafi':
-        style_comafi = red_button_style
-        style_naranja = white_button_style
+        style_comafi = selected_client_style
+        style_naranja = not_selected_button_style
 
     return client_id, style_naranja, style_comafi
+
+
+@app.callback(
+    Output("confirm-modal", "is_open"),
+    Input("btn-clear", "n_clicks"),
+    Input("cancel-btn", "n_clicks"),
+    Input("accept-btn", "n_clicks"),
+    State("confirm-modal", "is_open"),
+)
+def toggle_modal(n_clicks_1, n_clicks_2, n_clicks_3, is_open):
+    if n_clicks_1 or n_clicks_2 or n_clicks_3:
+        return not is_open
+    return is_open
+
+
+@app.callback(
+    Output("url", "href"),
+    Input("accept-btn", "n_clicks"),
+    prevent_initial_call=True,
+)
+def reload_page(n_clicks):
+    return "/"

--- a/web-app/components/clear_data.py
+++ b/web-app/components/clear_data.py
@@ -1,0 +1,38 @@
+import dash_bootstrap_components as dbc
+from dash import html
+
+
+class ClearData:
+
+    def create(self):
+
+        clear_button = html.Div(
+            [
+                html.I(className="fa-regular fa-trash-can", id="delete-cr", style={'marginRight': '1rem'}),
+                html.Span("Limpiar datos", className="clean-data-text"),
+            ],
+            id="btn-clear"
+        )
+        # dbc.Button("Limpiar datos", id="btn-clear", color="danger")
+
+        confirm_modal = dbc.Modal(
+            [
+                dbc.ModalHeader("Confirmación"),
+                dbc.ModalBody("¿Querés limpiar los datos?"),
+                dbc.ModalFooter(
+                    [
+                        dbc.Button("Cancelar", id="cancel-btn", className="mr-auto"),
+                        dbc.Button("Aceptar", id="accept-btn", color="danger"),
+                    ]
+                ),
+            ],
+            id="confirm-modal",
+            centered=True,
+        )
+
+        return html.Div([
+            html.Div([
+                clear_button,
+                confirm_modal,
+            ], className="clear-data-icon-span-container")
+        ], className="clear-data-container")

--- a/web-app/components/client_button.py
+++ b/web-app/components/client_button.py
@@ -25,7 +25,7 @@ class ClientButton:
         return html.Div([
             naranja,
             comafi,
-        ], style={'marginBottom': '4rem', 'marginTop': '4rem'}, className='tabs-container')
+        ], style={'marginBottom': '4rem', 'marginTop': '2rem'}, className='tabs-container')
 
     def style_button(self, button_id):
         if self.selected_button == button_id:

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -1,11 +1,13 @@
 from dash import html, dcc
 # import dash_bootstrap_components as dbc
+from components.clear_data import ClearData
 from components.client_button import ClientButton
 from components.upload import Upload
 
 
 client_button = ClientButton()
 upload = Upload()
+clear_data = ClearData()
 
 app_layout = html.Div([
     html.H1(
@@ -16,11 +18,16 @@ app_layout = html.Div([
             'marginLeft': '10px',
             'marginTop': '10px'
         }),
+    clear_data.create(),
+    html.Div([
+        html.P("Selecciona un cliente", className="selec-client")
+    ]),
     client_button.create(),
     html.Div(id='client-selected-value', style={'display': 'none'}),
     upload.create("1. Subir archivo para preparación de cuentas", id="cr", multiple_files=False),
     html.Div([
-                html.Div([], id="div-download", className="donwload-container")
-            ], id="major-div-download", className="major-donwload-container"),
-    dcc.Store(id='stored-dfs'),
+                html.Div([], id='div-download', className='donwload-container')
+            ], id='major-div-download', className='major-donwload-container'),
+    dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
+    dcc.Location(id='url', refresh=True),
 ])


### PR DESCRIPTION
- Adding clear data component
- Adding callback to the clear data button and to trigger a modal to confirm the action
- When we click the button to confirm the deletion, the page is refreshed which clears the data from dcc.Store
- Adding `storage_type='memory'` to dcc.Store

**Screenshots:**

- **State 1: initial state**

<img width="1785" alt="Screenshot 2023-05-11 at 20 26 51" src="https://github.com/alquimistas-org/subida_cartera/assets/30585029/610d8175-2776-47fa-9eea-52b47cea5877">

- **State 2: client selected and csv file uploaded**

<img width="1760" alt="Screenshot 2023-05-11 at 20 32 17" src="https://github.com/alquimistas-org/subida_cartera/assets/30585029/9611b73f-6027-4d17-834a-67a73c783b6e">

- **State 3: clear data clicked**

<img width="1757" alt="Screenshot 2023-05-11 at 20 32 23" src="https://github.com/alquimistas-org/subida_cartera/assets/30585029/96c76d78-a34a-467f-8869-6e4b4c24f40b">
