### PR TITLE
[DONT MERGE]refactor preparacion_datos

### DIFF
--- a/src/risk_data.py
+++ b/src/risk_data.py
@@ -1,17 +1,29 @@
 import pandas as pd
+
+from adapters.file_dataframe_saver import FileDataFrameSaver
 from constants.constants import (
     NUMBER_OF_COLUMNS,
     OSIRIS_ACCOUNTS_FILE_PATH,
     RISK_FILE_PATH,
+    ROOT_PATH,
 )
 from helpers import (
     get_phones,
     read_osiris_accounts,
 )
+from ports.dataframe_saver import DataFrameSaver
 from write_data_osiris import Escribir_Datos_Osiris
 
 
-def risk_data(risk_file_path=RISK_FILE_PATH, osiris_accounts_file_path=OSIRIS_ACCOUNTS_FILE_PATH) -> str:
+def risk_data(
+        risk_file_path=RISK_FILE_PATH,
+        osiris_accounts_file_path=OSIRIS_ACCOUNTS_FILE_PATH,
+        dataframe_saver: DataFrameSaver = None,
+        ) -> str:
+
+    if not dataframe_saver:
+        dataframe_saver = FileDataFrameSaver(output_path=ROOT_PATH / 'Subida Osiris/', portfolio_name='subida_cartera')
+
     'NECESARIOS: tener el archivos.csv de riesgo y el archivo de las cuentas de osiris como cuentas.csv'
     col_numbers = {
         'NÃºmero.1': 'tel_riesgo_1',
@@ -42,9 +54,13 @@ def risk_data(risk_file_path=RISK_FILE_PATH, osiris_accounts_file_path=OSIRIS_AC
 
     result_file_path = Escribir_Datos_Osiris(
         df_phone_risk,
-        'RIESGO_telefonos.csv',
+        'RIESGO_telefonos',
         ['Cuenta', 'ID_FONO', 'TEL', 'OBS'],
-        ["ID Cuenta o Nro. de Asig. (0)", "ID Tipo de Teléfono (17)", "Nro. de Teléfono (18)", "Obs. de Teléfono (19)"]
+        [
+            "ID Cuenta o Nro. de Asig. (0)", "ID Tipo de Teléfono (17)",
+            "Nro. de Teléfono (18)", "Obs. de Teléfono (19)",
+        ],
+        dataframe_saver,
     )
     print('Planilla de Teléfonos de RIESGO escrita')
     return result_file_path

--- a/src/write_data_osiris.py
+++ b/src/write_data_osiris.py
@@ -1,38 +1,20 @@
-
-from datetime import datetime
-import os
-
 import pandas as pd
+
 from constants.constants import (
     DATA_UPLOADER_HEADER,
-    ROOT_PATH,
 )
+from ports.dataframe_saver import DataFrameSaver
 
 
-def Escribir_Datos_Osiris(df: pd.DataFrame, filename: str, cols_df: 'list[str]', cols_osiris: 'list[str]'):
+def Escribir_Datos_Osiris(
+        df: pd.DataFrame,
+        name: str,
+        cols_df: 'list[str]',
+        cols_osiris: 'list[str]',
+        dataframe_saver: DataFrameSaver,
+        ):
 
-    if there_is_not_saved_files_directory():
-        raise Exception
-    result_file_path = ROOT_PATH / "Subida Osiris" / f'{datetime.now().strftime("(%H.%M hs) -")} {filename}'
     df_subida = pd.DataFrame(columns=DATA_UPLOADER_HEADER)
     df_subida[cols_osiris] = df[cols_df]
-    try:
-        df_subida.to_csv(
-            result_file_path,
-            sep=';',
-            index=False,
-            encoding='latin_1'
-        )
 
-    except Exception:
-        df_subida.to_csv(
-            result_file_path,
-            sep=';',
-            index=False,
-            encoding='ANSI'
-        )
-    return result_file_path
-
-
-def there_is_not_saved_files_directory():
-    return not os.path.isdir(ROOT_PATH / "Subida Osiris")
+    dataframe_saver.save_df(name=name, df=df_subida)

--- a/tests/test_data_info.py
+++ b/tests/test_data_info.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pandas as pd
-from unittest.mock import patch
 import pytest
+
+from pathlib import Path
+from unittest.mock import patch
+import tempfile
+
+from src.adapters.file_dataframe_saver import FileDataFrameSaver
 from src.data_info import GenerateDataInfo
 
 
@@ -65,7 +70,13 @@ class TestDataInfo:
     @patch('src.data_info.Escribir_Datos_Osiris')
     def test_write_phone_template(self, mock_write_data_osiris, mock_df_data_info):
 
-        GenerateDataInfo.write_phone_template(df=mock_df_data_info)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
+
+            GenerateDataInfo.write_phone_template(
+                df=mock_df_data_info,
+                dataframe_saver=saver,
+                )
 
         expected_df_phones = pd.DataFrame(
             {
@@ -81,7 +92,7 @@ class TestDataInfo:
         mock_write_data_osiris.assert_called_once()
         call_args = mock_write_data_osiris.call_args_list[0][0]
         pd.testing.assert_frame_equal(call_args[0], expected_df_phones)
-        assert call_args[1] == 'info_telefonos.csv'
+        assert call_args[1] == 'info_telefonos'
         assert call_args[2] == ['Cuenta', 'ID_FONO', 'TEL', 'OBS']
         assert call_args[3] == [
                 "ID Cuenta o Nro. de Asig. (0)",
@@ -93,7 +104,9 @@ class TestDataInfo:
     @patch('src.data_info.Escribir_Datos_Osiris')
     def test_write_salary_template(self, mock_write_data_osiris, mock_df_data_info):
 
-        GenerateDataInfo.write_salary_template(mock_df_data_info)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
+            GenerateDataInfo.write_salary_template(mock_df_data_info, saver)
         expected_df_info = pd.DataFrame(
             {
                 'Cuenta': '1234',
@@ -106,7 +119,7 @@ class TestDataInfo:
         mock_write_data_osiris.assert_called_once()
         call_args = mock_write_data_osiris.call_args_list[0][0]
         pd.testing.assert_frame_equal(call_args[0], expected_df_info)
-        assert call_args[1] == 'info_sueldo.csv'
+        assert call_args[1] == 'info_sueldo'
         assert call_args[2] == ['Cuenta', 'sueldo_info']
         assert call_args[3] == ["ID Cuenta o Nro. de Asig. (0)", "Sueldo (40)"]
 
@@ -122,20 +135,24 @@ class TestDataInfo:
                 index=[0]
             )
 
-        GenerateDataInfo.write_email_template(df=mock_df_data_info)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
+            GenerateDataInfo.write_email_template(df=mock_df_data_info, dataframe_saver=saver)
 
         # asserts
         mock_write_data_osiris.assert_called_once()
         call_args = mock_write_data_osiris.call_args_list[0][0]
         pd.testing.assert_frame_equal(call_args[0], mock_get_emails.return_value)
-        assert call_args[1] == 'info_mail.csv'
+        assert call_args[1] == 'info_mail'
         assert call_args[2] == ['Cuenta', 'MAIL_info']
         assert call_args[3] == ["ID Cuenta o Nro. de Asig. (0)", "Email (16)"]
 
     @patch('src.data_info.Escribir_Datos_Osiris')
     def test_write_q_vehicles_template(self, mock_write_data_osiris, mock_df_data_info):
 
-        GenerateDataInfo.write_q_vehicles_template(df=mock_df_data_info)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
+            GenerateDataInfo.write_q_vehicles_template(df=mock_df_data_info, dataframe_saver=saver)
         expected_df_info = pd.DataFrame(
             {
                 'Cuenta': '1234',
@@ -148,7 +165,7 @@ class TestDataInfo:
         mock_write_data_osiris.assert_called_once()
         call_args = mock_write_data_osiris.call_args_list[0][0]
         pd.testing.assert_frame_equal(call_args[0], expected_df_info)
-        assert call_args[1] == 'info_q_vehiculos.csv'
+        assert call_args[1] == 'info_q_vehiculos'
         assert call_args[2] == ['Cuenta', 'q_vehiculos']
         assert call_args[3] == ["ID Cuenta o Nro. de Asig. (0)", "Cantidad de Vehiculos (41)"]
 
@@ -170,7 +187,11 @@ class TestDataInfo:
                 'NSE_info': pd.Series([np.NaN for i in range(1, 15)]),
             }
         )
-        GenerateDataInfo.write_patrimonial_data_template(df=mock_df)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
+            GenerateDataInfo.write_patrimonial_data_template(df=mock_df, dataframe_saver=saver)
+
         expected_df = pd.DataFrame(
             {
                 'Cuenta': pd.Series(
@@ -216,7 +237,7 @@ class TestDataInfo:
         mock_write_data_osiris.assert_called_once()
         call_args = mock_write_data_osiris.call_args_list[0][0]
         pd.testing.assert_frame_equal(call_args[0], expected_df)
-        assert call_args[1] == 'info_patrimoniales.csv'
+        assert call_args[1] == 'info_patrimoniales'
         assert call_args[2] == ['Cuenta', 'primonial']
         assert call_args[3] == ["ID Cuenta o Nro. de Asig. (0)", "Datos Patrimoniales (42)"]
 

--- a/tests/test_risk_data.py
+++ b/tests/test_risk_data.py
@@ -1,6 +1,11 @@
 import pandas as pd
-from src.risk_data import risk_data
+
+from pathlib import Path
+import tempfile
 from unittest import mock
+
+from src.adapters.file_dataframe_saver import FileDataFrameSaver
+from src.risk_data import risk_data
 
 
 class TestRiskData:
@@ -56,23 +61,26 @@ class TestRiskData:
             index=[0]
         )
 
-        risk_data()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
+            risk_data(dataframe_saver=saver)
 
-        # asserts
-        mock_get_phones.assert_called_once_with(
-            df=mock_merge.return_value,
-            stop=5,
-            colum_name='RIESGO'
-        )
-        mock_Escribir_Datos_Osiris.assert_called_once()
-        mock_Escribir_Datos_Osiris.assert_called_once_with(
-            mock_get_phones.return_value,
-            'RIESGO_telefonos.csv',
-            ['Cuenta', 'ID_FONO', 'TEL', 'OBS'],
-            [
-                "ID Cuenta o Nro. de Asig. (0)",
-                "ID Tipo de Teléfono (17)",
-                "Nro. de Teléfono (18)",
-                "Obs. de Teléfono (19)"
-            ]
-        )
+            # asserts
+            mock_get_phones.assert_called_once_with(
+                df=mock_merge.return_value,
+                stop=5,
+                colum_name='RIESGO'
+            )
+            # mock_Escribir_Datos_Osiris.assert_called_once()
+            mock_Escribir_Datos_Osiris.assert_called_once_with(
+                mock_get_phones.return_value,
+                'RIESGO_telefonos',
+                ['Cuenta', 'ID_FONO', 'TEL', 'OBS'],
+                [
+                    "ID Cuenta o Nro. de Asig. (0)",
+                    "ID Tipo de Teléfono (17)",
+                    "Nro. de Teléfono (18)",
+                    "Obs. de Teléfono (19)"
+                ],
+                saver
+            )

--- a/tests/test_write_data_osiris.py
+++ b/tests/test_write_data_osiris.py
@@ -1,7 +1,11 @@
-from freezegun import freeze_time
 import pandas as pd
 import pytest
-from unittest import mock
+
+from freezegun import freeze_time
+from pathlib import Path
+import tempfile
+
+from src.adapters.file_dataframe_saver import FileDataFrameSaver
 from src.write_data_osiris import Escribir_Datos_Osiris
 
 
@@ -37,28 +41,12 @@ class TestWriteDataOsiris:
         mock_cols_df,
         mock_cols_osiris,
     ):
-
-        Escribir_Datos_Osiris(
-                df=mock_df,
-                filename=mock_filename,
-                cols_df=mock_cols_df,
-                cols_osiris=mock_cols_osiris,
-            )
-
-    @mock.patch('src.write_data_osiris.there_is_not_saved_files_directory')
-    def test_raise_exception_folder_doesnt_exist(
-        self,
-        mock_there_is_not_saved_files_directory,
-        mock_df,
-        mock_filename,
-        mock_cols_df,
-        mock_cols_osiris,
-    ):
-        mock_there_is_not_saved_files_directory.return_value = True
-        with pytest.raises(Exception):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saver = FileDataFrameSaver(output_path=Path(tmpdir))
             Escribir_Datos_Osiris(
-                df=mock_df,
-                filename=mock_filename,
-                cols_df=mock_cols_df,
-                cols_osiris=mock_cols_osiris,
-            )
+                    df=mock_df,
+                    name=mock_filename,
+                    cols_df=mock_cols_df,
+                    cols_osiris=mock_cols_osiris,
+                    dataframe_saver=saver,
+                )


### PR DESCRIPTION
To create the `preparacion_datos` GUI, the function had to be refactored.
Mainly to make the function use the `DataFrameSaver` interface so that the function can adapt to the hexagonal architecture.

Adding and using the new parameter (`DataFrameSaver`) caused various parts of the code to fail. Specifically, the `Escribir_datos_osiris` function also had to be refactored, and with it, all the other functions and tests that use it also had to be refactored.