### PR TITLE
Validate file and client selected

### DIFF
--- a/src/subida.py
+++ b/src/subida.py
@@ -43,11 +43,13 @@ def Preparacion_Cuentas(
     if not dataframe_saver:
         dataframe_saver = FileDataFrameSaver(output_path=ROOT_PATH / 'Subida Osiris/', portfolio_name='subida_cartera')
 
-    cr = read_data(cr_file_path)
-
-    df_os = process_cuentas(cr, NARANJA_FIELDS, ACCOUNT_PREP_COL)
-
-    write_csv(df_os, dataframe_saver)
+    try:
+        cr = read_data(cr_file_path)
+        df_os = process_cuentas(cr, NARANJA_FIELDS, ACCOUNT_PREP_COL)
+        write_csv(df_os, dataframe_saver)
+    except Exception as e:
+        print(f"Error: {e}")
+        return
 
 
 def Preparacion_Datos(cr_file_path=CR_FILE_PATH, osiris_accounts_file_path=OSIRIS_ACCOUNTS_FILE_PATH):

--- a/web-app/assets/style.css
+++ b/web-app/assets/style.css
@@ -194,3 +194,22 @@ a.upload-link-container{
     background-color: red;
     border-color: red;
 }
+
+#error-client-filename{
+    margin-top: 20rem;
+    text-align: center;
+}
+
+#accept-btn-error{
+   background-color: #1d8ab6;
+   border-color: #1d8ab6;
+}
+
+#accept-btn-error:hover{
+    background-color: #2cb7ee;
+    border-color: #2cb7ee;
+}
+
+#filename-error{
+    font-style: italic;
+}

--- a/web-app/callbacks_helpers.py
+++ b/web-app/callbacks_helpers.py
@@ -1,6 +1,8 @@
 import io
 from dash import html, dcc
 from pathlib import Path
+import dash_bootstrap_components as dbc
+from dash.exceptions import PreventUpdate
 from src.subida import Preparacion_Cuentas
 from src.prepare_comafi_accounts import prepare_comafi_accounts
 from src.adapters.dash_dataframe_saver import DashDataFrameSaver
@@ -15,8 +17,10 @@ def process_naranja_client(dash_dataframe_saver: DashDataFrameSaver, decoded, co
 
     dfs = dash_dataframe_saver.get_saved_dfs()
 
-    download_buttons = []
+    if not dfs:
+        raise PreventUpdate
 
+    download_buttons = []
     for key, _ in dfs.items():
         download_buttons.append(html.Div([
             html.Button([
@@ -44,6 +48,9 @@ def process_comafi_client(dash_dataframe_saver: DashDataFrameSaver, decoded, con
     )
 
     dfs = dash_dataframe_saver.get_saved_dfs()
+
+    if not dfs:
+        raise PreventUpdate
 
     download_buttons = []
     for key, _ in dfs.items():
@@ -73,3 +80,25 @@ def process_comafi_client(dash_dataframe_saver: DashDataFrameSaver, decoded, con
     data_dict['emerix'] = content_string
 
     return download_buttons, data_dict
+
+
+def display_modal_error(client_selected, filename):
+
+    modal_header = dbc.ModalHeader([
+        html.I(
+            className="fa-solid fa-circle-exclamation",
+            style={"color": "#f30010", "marginRight": "0.5rem"}
+        ),
+        html.Span("Error", style={"fontWeight": 400, "fontSize": "large"}),
+    ])
+    modal_body = dbc.ModalBody(
+        [
+            html.Span("No es posible procesar el archivo "),
+            html.Span(filename, id="filename-error"),
+            html.Span(f" para {client_selected[0].upper()}{client_selected[1:]}"),
+        ],
+        style={'fontSize': 'large', 'fontWeight': 400})
+    modal_footer = dbc.ModalFooter(
+        [dbc.Button("Aceptar", id="accept-btn-error")],
+    )
+    return True, [modal_header, modal_body, modal_footer]

--- a/web-app/components/clear_data.py
+++ b/web-app/components/clear_data.py
@@ -13,8 +13,6 @@ class ClearData:
             ],
             id="btn-clear"
         )
-        # dbc.Button("Limpiar datos", id="btn-clear", color="danger")
-
         confirm_modal = dbc.Modal(
             [
                 dbc.ModalHeader("Confirmación"),

--- a/web-app/components/upload.py
+++ b/web-app/components/upload.py
@@ -44,6 +44,7 @@ class Upload:
                 },
                 # Don't allow multiple files to be uploaded
                 multiple=multiple_files,
+                disabled=True,
             )
 
         collapse = dbc.Row(

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -1,5 +1,5 @@
 from dash import html, dcc
-# import dash_bootstrap_components as dbc
+import dash_bootstrap_components as dbc
 from components.clear_data import ClearData
 from components.client_button import ClientButton
 from components.upload import Upload
@@ -25,9 +25,15 @@ app_layout = html.Div([
     client_button.create(),
     html.Div(id='client-selected-value', style={'display': 'none'}),
     upload.create("1. Subir archivo para preparación de cuentas", id="cr", multiple_files=False),
-    html.Div([
-                html.Div([], id='div-download', className='donwload-container')
-            ], id='major-div-download', className='major-donwload-container'),
+    html.Div(
+        [
+            html.Div([], id="div-download", className="donwload-container")
+        ], id="major-div-download", className="major-donwload-container"),
     dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
     dcc.Location(id='url', refresh=True),
+    dbc.Modal([
+        dbc.ModalFooter(
+            [dbc.Button("Aceptar", id="accept-btn-error")],
+        ),
+    ], id='error-client-filename', is_open=False)
 ])


### PR DESCRIPTION
   - adding Modal component to inform file uploaded doesn't match with the client selected
   - adding callback function to process the modal
   - in `preparacion_cuentas` and `prepare_comafi_accounts` -> adding `try - except`, when there is an `Exception` just return `None`. So in the callback check if the dfs are None, raise a `PreventUpdate` and it doesn't store anything in dcc.Store.
   - then the callback function to process the modal checks if there is no data in dcc.Store to display the modal. 
   - adding typing in prepare_comafi_accounts helper functions
   - adding one function `read_comafi_data` 
    - disabling upload component if client is not selected
    - not updating upload component with filename if  file uploaded doesn't match with the client selected

Screenshots:

![image](https://github.com/alquimistas-org/subida_cartera/assets/30585029/3ad8443c-98d2-42cb-8f31-99a7086ed0c3)

![image](https://github.com/alquimistas-org/subida_cartera/assets/30585029/ad3b39cb-d326-4a00-a1c0-c0678a7812a7)

<img width="1759" alt="Screenshot 2023-05-15 at 10 46 01" src="https://github.com/alquimistas-org/subida_cartera/assets/30585029/e68dc942-ba10-4040-bf25-0649f60d2f10">

<img width="1766" alt="Screenshot 2023-05-15 at 10 46 32" src="https://github.com/alquimistas-org/subida_cartera/assets/30585029/db3e9d92-9f8e-4d40-b211-fa478507e0cc">


Upload component disabled when client is not selected:
![Screenshot 2023-05-16 at 17 10 12](https://github.com/alquimistas-org/subida_cartera/assets/30585029/8b157a68-13d9-4af3-a979-f554f3c74972)

Enable upload component when client is selected:
![Screenshot 2023-05-16 at 17 10 20](https://github.com/alquimistas-org/subida_cartera/assets/30585029/b540f4a8-c352-4d07-b985-ef220f5d79cb)

