### PR TITLE
Refactor Preparacion_Datos_Comafi

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -5,6 +5,7 @@ from constants.constants import (
     CR_FILE_PATH,
 )
 from src.constants.constants import DATA_PREP_COLUMNS
+from clean_numbers import clean_numbers
 
 
 def get_phones(df: pd.DataFrame, stop: int, colum_name: str) -> pd.DataFrame:
@@ -43,3 +44,16 @@ def read_cr_data(cr_file_path: Path = CR_FILE_PATH, columns_to_use: list = DATA_
 
     df_cr = cr[columns_to_use].rename(columns={'NRODOC': 'DNI'}, inplace=False).copy()
     return df_cr
+
+
+def process_phone_numbers(file_path: Path, cols: dict[str, str]) -> pd.DataFrame:
+    df_num = pd.read_excel(file_path, dtype=str)
+    df_num = df_num[list(cols.keys())]
+    df_num = df_num.rename(columns=cols)
+    df_num = df_num[df_num['telefono'].notna()]
+    df_num = clean_numbers(df_num)
+    df_num = df_num[['dni', 'telefono', 'telefono_2']]
+    df_num['telefono_2'] = df_num[df_num['telefono_2'].apply(len) >= 6]['telefono_2']
+    df_num = df_num[df_num['telefono_2'].notna()]
+
+    return df_num

--- a/src/utils/cuentas_processor_utils.py
+++ b/src/utils/cuentas_processor_utils.py
@@ -1,7 +1,8 @@
 from datetime import date
 
 import pandas as pd
-
+from pathlib import Path
+from typing import Union
 from constants.constants import YEARS_TO_ADD
 from ports.dataframe_saver import DataFrameSaver
 
@@ -12,11 +13,11 @@ def write_csv(df_os: pd.DataFrame, dataframe_saver: DataFrameSaver) -> None:
         dataframe_saver.save_df(name=name, df=df_sub)
 
 
-def read_data(cr_file_path: str) -> pd.DataFrame:
+def read_data(file_path: Union[str, Path]) -> pd.DataFrame:
     try:
-        return pd.read_csv(cr_file_path, sep=';', encoding='latin_1', dtype=str)
+        return pd.read_csv(file_path, sep=';', encoding='latin_1', dtype=str)
     except Exception:
-        return pd.read_csv(cr_file_path, sep=';', encoding='ANSI', dtype=str)
+        return pd.read_csv(file_path, sep=';', encoding='ANSI', dtype=str)
 
 
 def create_date(year_to_add: int = 0) -> date:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -150,8 +150,11 @@ def test_integration_comafi_data_preparation():
 
     expected_result_df = pd.read_csv(expected_result_file_path, encoding='latin-1', sep=';')
 
-    result_file_path = Preparacion_Datos_Comafi(emerix_df_file_path, osiris_accounts_df)
-    result_df = pd.read_csv(result_file_path, encoding='latin-1', sep=';')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        saver = FileDataFrameSaver(output_path=Path(tmpdir))
+        Preparacion_Datos_Comafi(emerix_df_file_path, osiris_accounts_df, saver)
+        saved_file = saver.get_saved_files()
+        result_df = pd.read_csv(saved_file['DATOS_EMERIX_subida_telefono'],  encoding='latin-1', sep=';')
 
     pd.testing.assert_frame_equal(result_df, expected_result_df)
 


### PR DESCRIPTION
- adding `dataframe saver` as param in `Preparacion_Datos_Comafi()`
- adpting type of `read_data` function to receives as param a `str` or a `Path`
- modifying integration test to use dataframe saver
- adding in helper functions: `process_phone_numbers` 