### PR TITLE
Data providers UI

### DIFF
--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -1,5 +1,13 @@
 from app import app
-from dash import Output, Input, State, html, dcc, MATCH, ctx
+from dash import (
+    Output,
+    Input,
+    State,
+    html,
+    dcc,
+    MATCH,
+    ctx
+)
 import base64
 from dash.exceptions import PreventUpdate
 from src.adapters.dash_dataframe_saver import DashDataFrameSaver
@@ -8,15 +16,18 @@ from callbacks_helpers import (
     process_comafi_client,
     display_modal_error,
 )
+from components.upload import Upload
 
 
-@app.callback(Output('div-download', 'children'),
-              Output('stored-dfs', 'data'),
-              Output('completed-first-step-btn', 'style'),
-              Input('upload-data-cr', 'contents'),
-              Input('client-selected-value', 'children'),
-              prevent_initial_call=True,
-              allow_duplicate=True,)
+@app.callback(
+    Output('div-download', 'children'),
+    Output('stored-dfs', 'data'),
+    Output('completed-first-step-btn', 'style'),
+    Input(Upload.get_upload_id('cr'), 'contents'),
+    Input('client-selected-value', 'children'),
+    prevent_initial_call=True,
+    allow_duplicate=True,
+)
 def upload_csv(list_of_contents, client_selected):
 
     if list_of_contents and client_selected:
@@ -54,7 +65,7 @@ def download_csv(n_clicks, dfs):
 @app.callback(
     Output("collapse-cr", "is_open"),
     Output("filename-cr", "children"),
-    Input("upload-data-cr", "filename"),
+    Input(Upload.get_upload_id('cr'), "filename"),
     State("collapse-cr", "is_open"),
     Input('client-selected-value', 'children'),
     Input('stored-dfs', 'data'),
@@ -124,9 +135,9 @@ def reload_page(n_clicks):
 
 
 @app.callback(
-    Output('upload-data-cr', 'disabled'),
+    Output(Upload.get_upload_id('cr'), 'disabled'),
     Input('client-selected-value', 'children'),
-    State('upload-data-cr', 'disabled')
+    State(Upload.get_upload_id('cr'), 'disabled')
 )
 def enable_upload_component(client_selected, disabled):
     if client_selected:
@@ -137,9 +148,9 @@ def enable_upload_component(client_selected, disabled):
 @app.callback(
               Output('error-client-filename', 'is_open'),
               Output('error-client-filename', 'children'),
-              Input('upload-data-cr', 'contents'),
+              Input(Upload.get_upload_id('cr'), 'contents'),
               Input('client-selected-value', 'children'),
-              Input("upload-data-cr", "filename"),
+              Input(Upload.get_upload_id('cr'), "filename"),
               Input("accept-btn-error", "n_clicks"),
               Input('stored-dfs', 'data'),
               State("error-client-filename", "is_open"),
@@ -150,7 +161,7 @@ def process_modal_error(list_of_contents, client_selected, filename, n_clicks, s
     if not list_of_contents and not client_selected:
         raise PreventUpdate
 
-    if ctx.triggered_id == 'upload-data-cr':
+    if ctx.triggered_id == Upload.get_upload_id('cr'):
         if not stored_data:
             return display_modal_error(client_selected, filename)
         raise PreventUpdate

--- a/web-app/components/download_button.py
+++ b/web-app/components/download_button.py
@@ -1,0 +1,38 @@
+from dash import (
+    html,
+    dcc,
+)
+
+
+class DownloadButton:
+    download_ico = html.I(
+                    className="fa-solid fa-circle-down",
+                    style={'marginRight': '10px'},
+                )
+
+    def create(cls, name: str):
+        return html.Div([
+                html.Button(
+                    [
+                        cls.download_ico,
+                        f"Descargar {name}"
+                    ],
+                    id=cls.get_button_id(name),
+                    className="download-button"
+                ),
+                dcc.Download(id=cls.get_dcc_download_id(name))
+            ])
+
+    @staticmethod
+    def get_button_id(name):
+        return {
+            "type": "btn-download",
+            "id": name,
+        }
+
+    @staticmethod
+    def get_dcc_download_id(name):
+        return {
+            "type": "download-csv",
+            "id": name,
+        }

--- a/web-app/components/external_data_providers_dropdown.py
+++ b/web-app/components/external_data_providers_dropdown.py
@@ -1,0 +1,20 @@
+from dash import dcc
+
+
+class ExternalDataProvidersDropDown:
+
+    data_providers = [
+        'Riesgo Online',
+        'Info Experto',
+    ]
+    id = 'external_data_providers_dropdown'
+
+    @classmethod
+    def create(cls):
+        return dcc.Dropdown(
+            id=cls.id,
+            options=[{'label': provider, 'value': provider} for provider in cls.data_providers],
+            value=cls.data_providers[0],
+            clearable=False,
+            style={'width': '100%'},
+        )

--- a/web-app/components/upload.py
+++ b/web-app/components/upload.py
@@ -1,17 +1,23 @@
-from dash import html, dcc
+from dash import (
+    html,
+    dcc,
+    ALL,
+    MATCH,
+)
 import dash_bootstrap_components as dbc
 
 
 class Upload:
 
-    def __init__(self, input_id='input', output_id='output') -> None:
-        self.input_id = input_id
-        self.output_id = output_id
-
-    def create(self, id: str, multiple_files: bool = False):
-
+    @classmethod
+    def create(
+        cls,
+        id: str,
+        multiple_files: bool = False,
+        upload_disabled: bool = True,
+    ):
         upload = dcc.Upload(
-                id=f'upload-data-{id}',
+                id=cls.get_upload_id(id),
                 children=html.Div([
                     html.A(
                         children=[
@@ -38,22 +44,42 @@ class Upload:
                 },
                 # Don't allow multiple files to be uploaded
                 multiple=multiple_files,
-                disabled=True,
+                disabled=upload_disabled,
             )
 
         collapse = dbc.Row(
             dbc.Col(
                 dbc.Collapse(
                     upload,
-                    id=f"collapse-{id}",
+                    id=cls.get_collapse_id(id),
                     is_open=True,
                 )
             ),
         )
 
-        filename_div = html.Div(id=f"filename-{id}", className="filaname-container")
+        filename_div = html.Div(id=cls.get_filename_div_id(id), className="filaname-container")
 
         return html.Div([
             collapse,
             filename_div,
         ])
+
+    @staticmethod
+    def get_upload_id(id: str) -> dict:
+        return {'type': 'upload-data', 'id': id}
+
+    @staticmethod
+    def get_upload_id_that_matchs():
+        return {'type': 'upload-data', 'id': MATCH}
+
+    @staticmethod
+    def get_all_upload_id():
+        return {'type': 'upload-data', 'id': ALL}
+
+    @staticmethod
+    def get_collapse_id(id: str):
+        return f"collapse-{id}"
+
+    @staticmethod
+    def get_filename_div_id(id: str):
+        return f"filename-{id}"

--- a/web-app/ids.py
+++ b/web-app/ids.py
@@ -1,0 +1,2 @@
+external_providers = 'external-providers'
+osiris_accounts = 'osiris-accounts'

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -1,15 +1,27 @@
 from dash import html, dcc
 import dash_bootstrap_components as dbc
+
 from components.clear_data import ClearData
 from components.client_button import ClientButton
 from components.upload import Upload
 from components.step_title import StepTitle
 from components.complete_step_btn import CompleteStepBtn
+from components.external_data_providers_dropdown import ExternalDataProvidersDropDown
+from ids import (
+    osiris_accounts,
+    external_providers,
+)
+
 
 client_button = ClientButton()
 clear_data = ClearData()
 first_step_title = StepTitle()
 complete_first_step = CompleteStepBtn(input_id='completed-first-step-btn')
+selected_client_style = {
+    'background-color': '#1d8ab6',
+    'border-color': '#1d8ab6',
+    'color': 'white',
+}
 
 app_layout = html.Div([
     html.H1(
@@ -20,33 +32,89 @@ app_layout = html.Div([
             'marginLeft': '10px',
             'marginTop': '10px'
         }),
-    clear_data.create(),
-    html.Div([
-        html.P("Selecciona un cliente", className="selec-client")
-    ]),
-    client_button.create(),
-    html.Div(id='client-selected-value', style={'display': 'none'}),
-    first_step_title.create(title_step="1. Subir archivo para preparación de cuentas"),
-    html.Div([
-        Upload.create(
-            id="cr",
-            multiple_files=False,
-        ),
-        html.Div(
-            [
-                html.Div([], id="div-download", className="donwload-container")
-            ], id="major-div-download", className="major-donwload-container"),
-        html.Div([
-            complete_first_step.create()
-            ], className='completed-step-bnt-container'),
+    dbc.Tabs(
+        [
+            dbc.Tab(
+                label="Cartera de Clientes",
+                active_label_style=selected_client_style,
+                children=[
+                    clear_data.create(),
+                    html.Div([
+                        html.P("Selecciona un cliente", className="selec-client")
+                    ]),
+                    client_button.create(),
+                    html.Div(id='client-selected-value', style={'display': 'none'}),
+                    first_step_title.create(title_step="1. Subir archivo para preparación de cuentas"),
+                    html.Div([
+                        Upload.create(
+                            id="cr",
+                            multiple_files=False,
+                        ),
+                        html.Div(
+                            [
+                                html.Div([], id="div-download", className="donwload-container")
+                            ], id="major-div-download", className="major-donwload-container"),
+                        html.Div([
+                            complete_first_step.create()
+                            ], className='completed-step-bnt-container'),
+                        ],
+                        id='first-step-container', className='step-container',
+                    ),
+                    dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
+                    dcc.Location(id='url', refresh=True),
+                    dbc.Modal([
+                        dbc.ModalFooter(
+                            [dbc.Button("Aceptar", id="accept-btn-error")],
+                        ),
+                    ], id='error-client-filename', is_open=False),
+                ],
+                id="tab_clientes",
+                tab_id="tab_clientes",
+            ),
+            dbc.Tab(
+                label="Proveedor de Datos",
+                active_label_style=selected_client_style,
+                children=[
+
+                    ExternalDataProvidersDropDown.create(),
+
+                    dbc.Row([
+                        dbc.Col([
+                            "1. Archivo cuentas de osiris",
+                            Upload.create(
+                                id=osiris_accounts,
+                                multiple_files=False,
+                                upload_disabled=False,
+                            ),
+                        ]),
+                        dbc.Col([
+                            "2. Archivo datos del proveedor",
+                            Upload.create(
+                                id=external_providers,
+                                multiple_files=False,
+                                upload_disabled=False,
+                            ),
+                        ]),
+                    ]),
+                    dbc.Row([
+                        dbc.Col(
+                            dbc.Button("Preparar datos", id="prepare_data_provider_button", color="primary"),
+                        )
+                    ]),
+                    dbc.Row([
+                        dbc.Col(
+                            'Resultado',
+                            id='result_prepare_data_provider',
+                        ),
+                    ]),
+                    dcc.Store(id='store-data-provider', data={}, clear_data=False, storage_type='session'),
+                ],
+                id="tab_data_providers",
+                tab_id="tab_data_providers",
+            ),
         ],
-        id='first-step-container', className='step-container',
-    ),
-    dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
-    dcc.Location(id='url', refresh=True),
-    dbc.Modal([
-        dbc.ModalFooter(
-            [dbc.Button("Aceptar", id="accept-btn-error")],
-        ),
-    ], id='error-client-filename', is_open=False),
+        active_tab='tab_data_providers',
+
+    )
+
 ])

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -7,7 +7,6 @@ from components.step_title import StepTitle
 from components.complete_step_btn import CompleteStepBtn
 
 client_button = ClientButton()
-upload = Upload()
 clear_data = ClearData()
 first_step_title = StepTitle()
 complete_first_step = CompleteStepBtn(input_id='completed-first-step-btn')
@@ -29,7 +28,10 @@ app_layout = html.Div([
     html.Div(id='client-selected-value', style={'display': 'none'}),
     first_step_title.create(title_step="1. Subir archivo para preparación de cuentas"),
     html.Div([
-        upload.create(id="cr", multiple_files=False),
+        Upload.create(
+            id="cr",
+            multiple_files=False,
+        ),
         html.Div(
             [
                 html.Div([], id="div-download", className="donwload-container")
@@ -46,5 +48,5 @@ app_layout = html.Div([
         dbc.ModalFooter(
             [dbc.Button("Aceptar", id="accept-btn-error")],
         ),
-    ], id='error-client-filename', is_open=False)
+    ], id='error-client-filename', is_open=False),
 ])


### PR DESCRIPTION
Several changes were made, each one in its own commit, to be atomic.


- refactor `upload` create method to be `classmethod` in order to reuse it
- add `staticmethods`  to upload class to get ids in different ways
- create an `ExternalDataProvider` dropdown
- create `download` buttons but don't use them already
- add `dbc.Tabs` to separate scops and be able to create another layout for external provider preparation

I didn't upload  the `callbacks` and the methods at `callbacks_helpers.py` that goes to the `src` (but I've already done them) I'm going to add them in another PR