### PR TITLE
Modified callbacs to use clients tabs

### DIFF
--- a/web-app/callbacks_helpers.py
+++ b/web-app/callbacks_helpers.py
@@ -90,7 +90,7 @@ def display_modal_error(client_selected, filename):
         [
             html.Span("No es posible procesar el archivo "),
             html.Span(filename, id="filename-error"),
-            html.Span(f" para {client_selected[0].upper()}{client_selected[1:]}"),
+            html.Span(f" para {client_selected['selected_client']}"),
         ],
         style={'fontSize': 'large', 'fontWeight': 400})
     modal_footer = dbc.ModalFooter(

--- a/web-app/components/clear_data.py
+++ b/web-app/components/clear_data.py
@@ -4,6 +4,7 @@ from dash import html
 
 class ClearData:
 
+    @classmethod
     def create(self):
 
         clear_button = html.Div(

--- a/web-app/components/clients_dropdown.py
+++ b/web-app/components/clients_dropdown.py
@@ -1,0 +1,24 @@
+from dash import dcc
+
+
+class ClientsDropdown:
+
+    clients = [
+        'Comafi',
+        'Naranja',
+    ]
+    id = 'clients_dropdown'
+
+    @classmethod
+    def create(cls):
+        return dcc.Dropdown(
+            id=cls.id,
+            options=[{'label': client, 'value': client} for client in cls.clients],
+            value=cls.clients[0],
+            clearable=False,
+            style={'width': '100%'},
+        )
+
+    @classmethod
+    def get_default_client(cls):
+        return cls.clients[0]

--- a/web-app/components/complete_step_btn.py
+++ b/web-app/components/complete_step_btn.py
@@ -3,11 +3,8 @@ from dash import html
 
 class CompleteStepBtn:
 
-    def __init__(self, input_id='input', output_id='output') -> None:
-        self.input_id = input_id
-        self.output_id = output_id
-
-    def create(self):
+    @classmethod
+    def create(self, id: str):
 
         btn = html.Div(
             [
@@ -18,7 +15,7 @@ class CompleteStepBtn:
                     id="check-step-icon"
                 ),
             ],
-            id=self.input_id,
+            id=id,
             style={'display': 'none'}
         )
 

--- a/web-app/components/step_title.py
+++ b/web-app/components/step_title.py
@@ -3,16 +3,13 @@ from dash import html
 
 class StepTitle:
 
-    def __init__(self, input_id='input', output_id='output') -> None:
-        self.input_id = input_id
-        self.output_id = output_id
-
-    def create(self, title_step: str):
+    @classmethod
+    def create(cls, title_step: str, step_id: str = "") -> html.Div:
 
         title = html.Div([
             html.Img(src="assets/attach-icon.svg", height=20, style={'marginLeft': '5px'}),
             html.Span(title_step, className="attach-file",),
-            html.Span(id="icon-success-upload"),
+            html.Span(id=f"icon-success-upload{step_id}"),
             html.Hr(style={"color": "black", "marginTop": "0"})
         ], className="step-title")
 

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -2,21 +2,16 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 
 from components.clear_data import ClearData
-from components.client_button import ClientButton
 from components.upload import Upload
 from components.step_title import StepTitle
 from components.complete_step_btn import CompleteStepBtn
+from components.clients_dropdown import ClientsDropdown
 from components.external_data_providers_dropdown import ExternalDataProvidersDropDown
 from ids import (
     osiris_accounts,
     external_providers,
 )
 
-
-client_button = ClientButton()
-clear_data = ClearData()
-first_step_title = StepTitle()
-complete_first_step = CompleteStepBtn(input_id='completed-first-step-btn')
 selected_client_style = {
     'background-color': '#1d8ab6',
     'border-color': '#1d8ab6',
@@ -24,6 +19,7 @@ selected_client_style = {
 }
 
 app_layout = html.Div([
+    ClearData.create(),
     html.H1(
         'Osiris',
         style={
@@ -31,90 +27,105 @@ app_layout = html.Div([
             'fontWeight': '800',
             'marginLeft': '10px',
             'marginTop': '10px'
-        }),
+        }
+    ),
     dbc.Tabs(
         [
-            dbc.Tab(
-                label="Cartera de Clientes",
-                active_label_style=selected_client_style,
-                children=[
-                    clear_data.create(),
-                    html.Div([
-                        html.P("Selecciona un cliente", className="selec-client")
-                    ]),
-                    client_button.create(),
-                    html.Div(id='client-selected-value', style={'display': 'none'}),
-                    first_step_title.create(title_step="1. Subir archivo para preparación de cuentas"),
-                    html.Div([
-                        Upload.create(
-                            id="cr",
-                            multiple_files=False,
-                        ),
-                        html.Div(
-                            [
-                                html.Div([], id="div-download", className="donwload-container")
-                            ], id="major-div-download", className="major-donwload-container"),
+                dbc.Tab(
+                    label="Cartera de Clientes",
+                    active_label_style=selected_client_style,
+                    children=[
                         html.Div([
-                            complete_first_step.create()
-                            ], className='completed-step-bnt-container'),
+                            html.P("Selecciona un cliente", className="selec-client")
+                        ]),
+                        ClientsDropdown.create(),
+                        StepTitle.create(title_step="1. Subir archivo para preparación cuentas", step_id='first'),
+                        html.Div(
+                            id="filename-uploaded-first-step",
+                            style={'display': 'none'},
+                            className='filaname-container'
+                        ),
+                        html.Div([
+                            Upload.create(
+                                id="prepare-accounts",
+                                multiple_files=False,
+                                upload_disabled=False,
+                            ),
+                            html.Div(
+                                [
+                                    html.Div(id="div-download", className="donwload-container")
+                                ],
+                                id="major-div-download",
+                                className="major-donwload-container"
+                            ),
+                            html.Div([
+                                CompleteStepBtn.create(id='complete-first-step-btn')
+                                ],
+                                className='completed-step-bnt-container'
+                            ),
+                        ], id='first-step-container'),
+                        dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
+                        dcc.Store(
+                            id='client-store',
+                            data={"selected_client": ClientsDropdown.get_default_client()},
+                            clear_data=False,
+                            storage_type='memory'
+                        ),
+                        dcc.Location(id='url', refresh=True),
+                        dbc.Modal([
+                            dbc.ModalFooter(
+                                [dbc.Button("Aceptar", id="accept-btn-error")],
+                            ),
+                        ], id='error-client-filename', is_open=False),
                         ],
-                        id='first-step-container', className='step-container',
+                    tab_id="clients_tabs"
+                ),
+                dbc.Tab(
+                    label="Proveedor de Datos",
+                    active_label_style=selected_client_style,
+                    children=[
+                        ExternalDataProvidersDropDown.create(),
+                        dbc.Row([
+                            dbc.Col(
+                                [
+                                    StepTitle.create(title_step="1. Archivo cuentas de osiris"),
+                                    Upload().create(
+                                        id=osiris_accounts,
+                                        multiple_files=False,
+                                        upload_disabled=False,
+                                    )
+                                ]
+                            ),
+                            dbc.Col(
+                                [
+                                    StepTitle.create(
+                                        title_step="2. Archivo datos del proveedor"),
+                                    Upload.create(
+                                        id=external_providers,
+                                        multiple_files=False,
+                                        upload_disabled=False,
+                                    ),
+                                    ]
+                                ),
+                            ]),
+                        dbc.Row([
+                            dbc.Col(
+                                dbc.Button("Preparar datos", id="prepare_data_provider_button", color="primary"),
+                            )
+                        ]),
+                        dbc.Row([
+                            dbc.Col(
+                                'Resultado',
+                                id='result_prepare_data_provider',
+                            ),
+                        ]),
+                        dcc.Store(id='store-data-provider', data={}, clear_data=False, storage_type='session')
+                    ],
+                    id="tab_data_providers",
+                    tab_id="tab_data_providers",
                     ),
-                    dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
-                    dcc.Location(id='url', refresh=True),
-                    dbc.Modal([
-                        dbc.ModalFooter(
-                            [dbc.Button("Aceptar", id="accept-btn-error")],
-                        ),
-                    ], id='error-client-filename', is_open=False),
                 ],
-                id="tab_clientes",
-                tab_id="tab_clientes",
-            ),
-            dbc.Tab(
-                label="Proveedor de Datos",
-                active_label_style=selected_client_style,
-                children=[
-
-                    ExternalDataProvidersDropDown.create(),
-
-                    dbc.Row([
-                        dbc.Col([
-                            "1. Archivo cuentas de osiris",
-                            Upload.create(
-                                id=osiris_accounts,
-                                multiple_files=False,
-                                upload_disabled=False,
-                            ),
-                        ]),
-                        dbc.Col([
-                            "2. Archivo datos del proveedor",
-                            Upload.create(
-                                id=external_providers,
-                                multiple_files=False,
-                                upload_disabled=False,
-                            ),
-                        ]),
-                    ]),
-                    dbc.Row([
-                        dbc.Col(
-                            dbc.Button("Preparar datos", id="prepare_data_provider_button", color="primary"),
-                        )
-                    ]),
-                    dbc.Row([
-                        dbc.Col(
-                            'Resultado',
-                            id='result_prepare_data_provider',
-                        ),
-                    ]),
-                    dcc.Store(id='store-data-provider', data={}, clear_data=False, storage_type='session'),
-                ],
-                id="tab_data_providers",
-                tab_id="tab_data_providers",
-            ),
-        ],
-        active_tab='tab_data_providers',
-
-    )
-
-])
+        active_tab='clients_tabs',
+        ),
+    ],
+)


### PR DESCRIPTION
Continuing with Mati's approach: [PR](https://github.com/alquimistas-org/subida_cartera/pull/39)

- Updating these callbacks:
	- `upload_csv`
	- `collapse_upload`
	- `get_client` - `process_modal_error` - `mark_fist_step_as_completed`
- Adding a dropdown to choose a client: `ClientDropdown`
- In the `layout.py` file adding a `dcc.Store` to store the client selected, for default is the first element of the ClientDropdown
- Modifying `StepTitle`, `CompleteStepBtn`,  and `ClearData` create methods to be a `classmethod`
- Deleting client_button.py because is not used anymore.

Screenshoots:
![Screenshot 2023-06-02 at 10 41 21](https://github.com/alquimistas-org/subida_cartera/assets/30585029/6594fa31-208a-4c66-aa7c-c5c622d467dc)
![Screenshot 2023-06-02 at 10 41 46](https://github.com/alquimistas-org/subida_cartera/assets/30585029/dd47985b-4b25-498f-9674-540837ca7afa)
![Screenshot 2023-06-02 at 10 41 59](https://github.com/alquimistas-org/subida_cartera/assets/30585029/26391d77-3f5a-4191-a965-ab936bd7d005)
![Screenshot 2023-06-02 at 10 42 14](https://github.com/alquimistas-org/subida_cartera/assets/30585029/de6f02e8-adb2-4799-b6c5-3d48b9644401)
![Screenshot 2023-06-02 at 10 42 50](https://github.com/alquimistas-org/subida_cartera/assets/30585029/affdbea6-6ef6-474f-aca0-baf0e8b7aa86)
![Screenshot 2023-06-02 at 10 45 37](https://github.com/alquimistas-org/subida_cartera/assets/30585029/6b5b61b8-538f-466e-b9ae-62afc2ec3d5e)

