### PR TITLE
Essential connection provider UI to backend

### DIFF
--- a/src/data_info.py
+++ b/src/data_info.py
@@ -240,10 +240,3 @@ class GenerateDataInfo:
         cls.write_email_template(df, dataframe_saver)
         cls.write_q_vehicles_template(df, dataframe_saver)
         cls.write_patrimonial_data_template(df, dataframe_saver)
-
-        all_result_file_paths = [
-            result_file_path
-            for result_file_path in dataframe_saver.get_saved_files().values()
-        ]
-
-        return all_result_file_paths

--- a/src/write_data_osiris.py
+++ b/src/write_data_osiris.py
@@ -8,6 +8,7 @@ from constants.constants import (
     ROOT_PATH,
 )
 from ports.dataframe_saver import DataFrameSaver
+from adapters.dash_dataframe_saver import DashDataFrameSaver
 
 
 def Escribir_Datos_Osiris(
@@ -18,7 +19,12 @@ def Escribir_Datos_Osiris(
     dataframe_saver: DataFrameSaver,
 ) -> None:
 
-    if there_is_not_saved_files_directory():
+    if (
+        there_is_not_saved_files_directory() and
+        dataframe_saver.__class__.__name__ != DashDataFrameSaver.__name__
+    ):
+        # TODO: this check only had sense when the app was a desktop app
+        #      once it starts working as web app, this check is not be necessary
         raise Exception
     df_subida = pd.DataFrame(columns=DATA_UPLOADER_HEADER)
     df_subida[cols_osiris] = df[cols_df]

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -16,10 +16,11 @@ from callbacks_helpers import (
     process_comafi_client,
     display_modal_error,
 )
+from components.download_area import DownloadButtonsArea
 from components.upload import Upload
 
 
-@app.callback(Output('div-download', 'children'),
+@app.callback(Output(DownloadButtonsArea.get_id("prepare"), 'children'),
               Output('stored-dfs', 'data'),
               Output('complete-first-step-btn', 'style'),
               Input(Upload.get_upload_id('prepare-accounts'), 'contents'),

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -1,3 +1,5 @@
+import io
+
 from app import app
 from dash import (
     Output,
@@ -12,12 +14,18 @@ import base64
 from dash.exceptions import PreventUpdate
 from src.adapters.dash_dataframe_saver import DashDataFrameSaver
 from callbacks_helpers import (
-    process_naranja_client,
-    process_comafi_client,
     display_modal_error,
+    get_id_and_value_from_context,
+    process_comafi_client,
+    process_external_provider_data,
+    process_naranja_client,
 )
 from components.download_area import DownloadButtonsArea
 from components.upload import Upload
+from ids import (
+    external_providers,
+    osiris_accounts,
+)
 
 
 @app.callback(Output(DownloadButtonsArea.get_id("prepare"), 'children'),
@@ -157,3 +165,89 @@ def mark_fist_step_as_completed(n_clicks):
         ),
         {'display': 'none'},
         )
+
+
+@app.callback(
+    Output('store-data-provider', 'data', allow_duplicate=True),
+    Input(Upload.get_all_upload_id(), 'contents'),
+    State(Upload.get_all_upload_id(), 'filename'),
+    State('store-data-provider', 'data'),
+    prevent_initial_call=True,
+)
+def upload_csv_without_process(_, __, data_store):
+
+    triggered_input_id, triggered_file_content, triggered_file_name = get_id_and_value_from_context()
+    if (
+        triggered_file_content and
+        (
+            triggered_input_id == Upload.get_upload_id(external_providers) or
+            triggered_input_id == Upload.get_upload_id(osiris_accounts)
+        )
+    ):
+
+        if triggered_input_id == Upload.get_upload_id(external_providers):
+            data_name = external_providers
+        else:
+            data_name = osiris_accounts
+        content_type, content_data = triggered_file_content.split(',')
+        data_store.update(
+            {
+                data_name: {
+                    'content_type': content_type,
+                    'filename': triggered_file_name,
+                    'data': content_data,
+                }
+            }
+        )
+        return data_store
+    raise PreventUpdate
+
+
+@app.callback(
+    Output(DownloadButtonsArea.get_id("prepare-external-data-provider"), 'children'),
+    Output('store-data-provider', 'data'),
+    Input('prepare_data_provider_button', 'n_clicks'),
+    State('external_data_providers_dropdown', 'value'),
+    State('store-data-provider', 'data'),
+)
+def process_provider_data(
+    click: int,
+    external_provider_name: str,
+    data_store: dict,
+):
+
+    osiris_accunts_data = data_store.get('osiris-accounts')
+    external_provider_data = data_store.get('external-providers')
+
+    if click and external_provider_name and osiris_accunts_data and external_provider_data:
+
+        dash_dataframe_saver = DashDataFrameSaver()
+        osiris_accunts_data = io.BytesIO(base64.b64decode(osiris_accunts_data.get('data')))
+        external_provider_data = io.BytesIO(base64.b64decode(external_provider_data.get('data')))
+
+        download_buttons, result_data = process_external_provider_data(
+            dash_dataframe_saver,
+            osiris_accunts_data,
+            external_provider_data,
+            external_provider_name,
+        )
+        data_store.update({
+            'results': result_data,
+        })
+        return download_buttons, data_store
+    raise PreventUpdate
+
+
+@app.callback(
+    Output({"type": "download-csv", "id": MATCH}, "data", allow_duplicate=True),
+    Input({"type": "btn-download", "id": MATCH}, "n_clicks"),
+    Input('store-data-provider', 'data'),
+    prevent_initial_call=True,
+    allow_duplicate=True,
+)
+def download_csv_data_provider(n_clicks, dfs):
+    if not n_clicks:
+        raise PreventUpdate
+    df_id = ctx.triggered_id["id"]
+    df = dfs.get('results')[df_id]
+    return dcc.send_string(df, df_id)

--- a/web-app/callbacks_helpers.py
+++ b/web-app/callbacks_helpers.py
@@ -1,12 +1,22 @@
 import io
-from dash import html, dcc
 from pathlib import Path
-import dash_bootstrap_components as dbc
+from typing import List, Tuple
+
+from dash import (
+    ctx,
+    dcc,
+    html,
+)
 from dash.exceptions import PreventUpdate
-from src.subida import Preparacion_Cuentas
-from src.prepare_comafi_accounts import prepare_comafi_accounts
+import dash_bootstrap_components as dbc
+
+from components.download_button import DownloadButton
 from src.adapters.dash_dataframe_saver import DashDataFrameSaver
 from src.constants.constants import ACCOUNTS_MODEL_CSV_PATH
+from src.data_info import GenerateDataInfo
+from src.prepare_comafi_accounts import prepare_comafi_accounts
+from src.risk_data import risk_data
+from src.subida import Preparacion_Cuentas
 
 
 def process_naranja_client(dash_dataframe_saver: DashDataFrameSaver, decoded, content_string):
@@ -97,3 +107,46 @@ def display_modal_error(client_selected, filename):
         [dbc.Button("Aceptar", id="accept-btn-error")],
     )
     return True, [modal_header, modal_body, modal_footer]
+
+
+def get_id_and_value_from_context():
+    if not ctx.triggered:
+        raise PreventUpdate
+    triggered_id = ctx.triggered_id
+    triggered_input_value = ctx.triggered[0]['value']
+    triggered_state_value = [value for key, value in ctx.states.items() if triggered_id.get('id') in key][0]
+    return triggered_id, triggered_input_value, triggered_state_value
+
+
+def process_external_provider_data(
+    dash_dataframe_saver: DashDataFrameSaver,
+    osiris_accounts_data: dict,
+    external_provider_data: dict,
+    external_provider_name: str,
+) -> Tuple[List[DownloadButton], dict]:
+    if external_provider_name == 'riesgo-online':
+        risk_data(
+            risk_file_path=external_provider_data,
+            osiris_accounts_file_path=osiris_accounts_data,
+            dataframe_saver=dash_dataframe_saver
+        )
+    else:
+        GenerateDataInfo.process(
+            osiris_accounts_data=osiris_accounts_data,
+            external_provider_data=external_provider_data,
+            dataframe_saver=dash_dataframe_saver
+        )
+
+    dfs = dash_dataframe_saver.get_saved_dfs()
+
+    if not dfs:
+        raise PreventUpdate
+
+    download_buttons = [
+        DownloadButton.create(df_name)
+        for df_name in dfs.keys()
+    ]
+
+    result_data = {df_name: df.to_csv(index=False) for df_name, df in dfs.items()}
+
+    return download_buttons, result_data

--- a/web-app/components/download_area.py
+++ b/web-app/components/download_area.py
@@ -1,0 +1,23 @@
+from dash import html
+
+
+class DownloadButtonsArea:
+
+    @classmethod
+    def create(cls, name: str) -> html.Div:
+        return html.Div(
+            [
+                html.Div(id=cls.get_id(name), className="donwload-container")
+            ],
+            id=cls.get_id_major_div(name),
+            className="major-donwload-container"
+        )
+
+    @staticmethod
+    def get_id(name: str) -> str:
+        """principal id used in callbacks"""
+        return f"div-download-{name}"
+
+    @staticmethod
+    def get_id_major_div(name: str) -> str:
+        return f"major-div-download-{name}"

--- a/web-app/components/download_button.py
+++ b/web-app/components/download_button.py
@@ -10,6 +10,7 @@ class DownloadButton:
                     style={'marginRight': '10px'},
                 )
 
+    @classmethod
     def create(cls, name: str):
         return html.Div([
                 html.Button(

--- a/web-app/components/external_data_providers_dropdown.py
+++ b/web-app/components/external_data_providers_dropdown.py
@@ -3,18 +3,18 @@ from dash import dcc
 
 class ExternalDataProvidersDropDown:
 
-    data_providers = [
-        'Riesgo Online',
-        'Info Experto',
-    ]
+    data_providers = {
+        'Riesgo Online': 'riesgo-online',
+        'Info Experto': 'info-experto',
+    }
     id = 'external_data_providers_dropdown'
 
     @classmethod
     def create(cls):
         return dcc.Dropdown(
             id=cls.id,
-            options=[{'label': provider, 'value': provider} for provider in cls.data_providers],
-            value=cls.data_providers[0],
+            options=[{'label': label, 'value': value} for label, value in cls.data_providers.items()],
+            value=list(cls.data_providers.values())[0],
             clearable=False,
             style={'width': '100%'},
         )

--- a/web-app/ids.py
+++ b/web-app/ids.py
@@ -1,2 +1,3 @@
 external_providers = 'external-providers'
 osiris_accounts = 'osiris-accounts'
+prepare_accounts = "prepare-accounts"

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -2,6 +2,7 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 
 from components.clear_data import ClearData
+from components.download_area import DownloadButtonsArea
 from components.upload import Upload
 from components.step_title import StepTitle
 from components.complete_step_btn import CompleteStepBtn
@@ -51,13 +52,7 @@ app_layout = html.Div([
                                 multiple_files=False,
                                 upload_disabled=False,
                             ),
-                            html.Div(
-                                [
-                                    html.Div(id="div-download", className="donwload-container")
-                                ],
-                                id="major-div-download",
-                                className="major-donwload-container"
-                            ),
+                            DownloadButtonsArea.create("prepare-accounts"),
                             html.Div([
                                 CompleteStepBtn.create(id='complete-first-step-btn')
                                 ],
@@ -89,7 +84,7 @@ app_layout = html.Div([
                             dbc.Col(
                                 [
                                     StepTitle.create(title_step="1. Archivo cuentas de osiris"),
-                                    Upload().create(
+                                    Upload.create(
                                         id=osiris_accounts,
                                         multiple_files=False,
                                         upload_disabled=False,

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -83,7 +83,10 @@ app_layout = html.Div([
                         dbc.Row([
                             dbc.Col(
                                 [
-                                    StepTitle.create(title_step="1. Archivo cuentas de osiris"),
+                                    StepTitle.create(
+                                        title_step="1. Archivo cuentas de osiris",
+                                        step_id='external-data-provider',
+                                    ),
                                     Upload.create(
                                         id=osiris_accounts,
                                         multiple_files=False,
@@ -94,7 +97,7 @@ app_layout = html.Div([
                             dbc.Col(
                                 [
                                     StepTitle.create(
-                                        title_step="2. Archivo datos del proveedor"),
+                                        title_step="2. Archivo datos del proveedor", step_id='osiris-accounts'),
                                     Upload.create(
                                         id=external_providers,
                                         multiple_files=False,
@@ -108,12 +111,7 @@ app_layout = html.Div([
                                 dbc.Button("Preparar datos", id="prepare_data_provider_button", color="primary"),
                             )
                         ]),
-                        dbc.Row([
-                            dbc.Col(
-                                'Resultado',
-                                id='result_prepare_data_provider',
-                            ),
-                        ]),
+                        DownloadButtonsArea.create("prepare-external-data-provider"),
                         dcc.Store(id='store-data-provider', data={}, clear_data=False, storage_type='session')
                     ],
                     id="tab_data_providers",


### PR DESCRIPTION
All these changes are only the essential ones to leave working on the data provider tab.
Some callbacks and method seems to be repeated, I know that. I will change them in the next iteration.
Changes:
- create a `DownloadButtonArea` to reuse code
- Fix some mistakes in previous commits of mine
- Add id t `StepTitle` of data provider tab
- Fix some code in `src`
    - `data_info` was returning the paths list, and we must do I with the `dataframe_saver` (fix the test too
    - the check of the directory is not needed in `web-app`
    - add the callbacks repeating some parts of the code that I will changes in the following PR