### PR TITLE
 Callback fixed

### DIFF
--- a/web-app/assets/style.css
+++ b/web-app/assets/style.css
@@ -78,7 +78,7 @@ a.upload-link-container{
 
 .download-button{
     width: 30rem;
-    border-radius: 10px;
+    border-radius: 5px;
     color: #ffffff;
     background-color: #1d8ab6;
     border-color: #1d8ab6;
@@ -227,11 +227,20 @@ a.upload-link-container{
     display: flex;
     justify-content: center;
     margin-top: 3rem;
+
 }
 
-.completed-step-btn:hover{
+#complete-first-step-btn{
+    color: white;
+    background-color: #27c12a;
+    border-color: #27c12a;
+    border-radius: 5px;
+}
+
+#complete-first-step-btn:hover{
     cursor: pointer;
-    color: #24c927;
+    background-color: #6ed570;
+    border-color: #6ed570;
 }
 
 .fa-circle-check{

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -49,15 +49,15 @@ def upload_csv(list_of_contents, client_selected):
         elif client_selected['selected_client'] == 'Comafi':
             download_buttons, data_dict = process_comafi_client(dash_dataframe_saver, decoded, content_string)
 
-        return download_buttons, data_dict, {'display': 'block'}
+        return download_buttons, data_dict, {'display': 'block', 'textTransform': 'lowercase'}
 
     else:
         raise PreventUpdate
 
 
 @app.callback(
-    Output({"type": "download-csv", "id": MATCH}, "data"),
-    Input({"type": "btn-download", "id": MATCH}, "n_clicks"),
+    Output({"type": "download-csv-accounts", "id": MATCH}, "data"),
+    Input({"type": "btn-download-accounts", "id": MATCH}, "n_clicks"),
     Input('stored-dfs', 'data'),
     prevent_initial_call=True,
     allow_duplicate=True,
@@ -143,7 +143,7 @@ def process_modal_error(list_of_contents, client_selected, filename, n_clicks, s
         raise PreventUpdate
 
     elif ctx.triggered_id == 'accept-btn-error':
-        return not is_open, []
+        return not is_open, html.Div(id="accept-btn-error")
 
     else:
         raise PreventUpdate

--- a/web-app/callbacks_helpers.py
+++ b/web-app/callbacks_helpers.py
@@ -40,10 +40,10 @@ def process_naranja_client(dash_dataframe_saver: DashDataFrameSaver, decoded, co
                     style={'marginRight': '0.5rem', 'fontSize': 'large', 'marginTop': '1rem'}
                 ),
             ], id={
-                "type": "btn-download",
+                "type": "btn-download-accounts",
                 "id": key
             }, className="download-button"),
-            dcc.Download(id={"type": "download-csv", "id": key})
+            dcc.Download(id={"type": "download-csv-accounts", "id": key})
         ]))
 
     data_dict = {key: value.to_csv() for key, value in dfs.items()}
@@ -75,10 +75,10 @@ def process_comafi_client(dash_dataframe_saver: DashDataFrameSaver, decoded, con
                     style={'marginRight': '0.5rem', 'fontSize': 'large', 'marginTop': '1rem'}
                 ),
             ], id={
-                "type": "btn-download",
+                "type": "btn-download-accounts",
                 "id": key
             }, className="download-button"),
-            dcc.Download(id={"type": "download-csv", "id": key})
+            dcc.Download(id={"type": "download-csv-accounts", "id": key})
         ]))
 
     data_dict = {key: value.to_csv() for key, value in dfs.items()}

--- a/web-app/components/complete_step_btn.py
+++ b/web-app/components/complete_step_btn.py
@@ -6,12 +6,12 @@ class CompleteStepBtn:
     @classmethod
     def create(self, id: str):
 
-        btn = html.Div(
+        btn = html.Button(
             [
-                html.Span("Completar este paso", className="completed-step-btn", style={"fontSize": "x-large"}),
+                html.Span("Completar este paso", className="completed-step-btn", style={"fontSize": "medium"}),
                 html.I(
                     className="fa-regular fa-circle-check",
-                    style={"color": "#24c927", 'marginLeft': '0.7rem', 'fontSize': 'x-large'},
+                    style={"color": "white", 'marginLeft': '0.7rem', 'fontSize': 'x-large'},
                     id="check-step-icon"
                 ),
             ],

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -52,7 +52,7 @@ app_layout = html.Div([
                                 multiple_files=False,
                                 upload_disabled=False,
                             ),
-                            DownloadButtonsArea.create("prepare-accounts"),
+                            DownloadButtonsArea.create("prepare"),
                             html.Div([
                                 CompleteStepBtn.create(id='complete-first-step-btn')
                                 ],


### PR DESCRIPTION
- Modified `process_naranja_client` and `process_comafi_client` callback helpers -> changed `id type` of btn, because they had the same id of `download_csv_data_provider` input and it broked `download_csv` callback. So when I uploaded cr.csv or emerix file to process naranja and comafi it didn't show the donwloads buttons.
- Changed the id of `DownloadButtonsArea` in layout inside of Cartera de Clientes, to match `DownloadButtonsArea.get_id("prepare")` in `upload_csv` output callback.
- Changed 'complete step' btn style (style.css file) and using `html.Button` instead of `html.Div` in `CompleteStepBtn` component.