### PR TITLE
refactoring process_client to be reusable

### DIFF
--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -16,9 +16,8 @@ from src.adapters.dash_dataframe_saver import DashDataFrameSaver
 from callbacks_helpers import (
     display_modal_error,
     get_id_and_value_from_context,
-    process_comafi_client,
     process_external_provider_data,
-    process_naranja_client,
+    process_client,
 )
 from components.download_area import DownloadButtonsArea
 from components.upload import Upload
@@ -43,11 +42,13 @@ def upload_csv(list_of_contents, client_selected):
         dash_dataframe_saver = DashDataFrameSaver()
         download_buttons = []
         data_dict = {}
-        if client_selected['selected_client'] == 'Naranja':
-            download_buttons, data_dict = process_naranja_client(dash_dataframe_saver, decoded, content_string)
 
-        elif client_selected['selected_client'] == 'Comafi':
-            download_buttons, data_dict = process_comafi_client(dash_dataframe_saver, decoded, content_string)
+        download_buttons, data_dict = process_client(
+            client_selected['selected_client'],
+            dash_dataframe_saver,
+            decoded,
+            content_string,
+            )
 
         return download_buttons, data_dict, {'display': 'block', 'textTransform': 'lowercase'}
 

--- a/web-app/callbacks_helpers.py
+++ b/web-app/callbacks_helpers.py
@@ -17,6 +17,10 @@ from src.data_info import GenerateDataInfo
 from src.prepare_comafi_accounts import prepare_comafi_accounts
 from src.risk_data import risk_data
 from src.subida import Preparacion_Cuentas
+from web_constants import (
+    COMAFI,
+    NARANJA,
+    )
 
 
 def process_naranja_client(dash_dataframe_saver: DashDataFrameSaver, decoded, content_string):
@@ -150,3 +154,13 @@ def process_external_provider_data(
     result_data = {df_name: df.to_csv(index=False) for df_name, df in dfs.items()}
 
     return download_buttons, result_data
+
+
+CLIENT_STRATEGY = {
+    COMAFI: process_comafi_client,
+    NARANJA: process_naranja_client,
+}
+
+
+def process_client(strategy, dash_dataframe_saver: DashDataFrameSaver, decoded, content_string):
+    return CLIENT_STRATEGY[strategy](dash_dataframe_saver, decoded, content_string)

--- a/web-app/web_constants.py
+++ b/web-app/web_constants.py
@@ -1,0 +1,3 @@
+
+COMAFI = 'Comafi'
+NARANJA = 'Naranja'


### PR DESCRIPTION
In order to make the process client reusable, I add a pseudo-strategy pattern to manage the calls of the different methods of the backend