### PR TITLE
Modified assets path in app file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN pipenv install --dev --system
 
 ENV DEBUG="0"
 
+ENV WEB_APP_PATH="/web-app"
+
 COPY . .
 
 EXPOSE 8050

--- a/web-app/app.py
+++ b/web-app/app.py
@@ -2,8 +2,8 @@ import dash
 import dash_bootstrap_components as dbc
 import os
 
-
-assets_path = os.getcwd() + '/assets'
+web_app_path = os.getenv("WEB_APP_PATH", "")
+assets_path = os.getcwd() + f'{web_app_path}/assets'
 external_stylesheets = [
     dbc.themes.MATERIA,
     dbc.icons.FONT_AWESOME,


### PR DESCRIPTION
- Adding in `Dockerfile` the env variable `WEB_APP_PATH="/web-app"` to use it in `assets_path` in the app configuration (`app.py`), because when the dash app was running with docker it didn't find the assets folder.
- Now, if the app is running with docker it will use the env variable. And if the app is running locally, the value of the env variable will be an empty string and it will find the assets folder (running` python main.py` within the `web-app folder`).