### PR TITLE
Tune web app

### DIFF
--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -23,6 +23,7 @@ from callbacks_helpers import (
 from components import (
     CompleteStepBtn,
     DownloadButtonsArea,
+    FilenameUploaded,
     StepTitle,
     Upload,
     )
@@ -80,8 +81,8 @@ def download_csv(n_clicks, dfs):
 
 @app.callback(
     Output(Upload.get_collapse_id('prepare-accounts'), "is_open"),
-    Output("filename-uploaded-first-step", "children"),
-    Output("filename-uploaded-first-step", "style"),
+    Output(FilenameUploaded.get_id('client-first-step'), "children"),
+    Output(FilenameUploaded.get_id('client-first-step'), "style"),
     Input(Upload.get_upload_id('prepare-accounts'), "filename"),
     State(Upload.get_collapse_id('prepare-accounts'), "is_open"),
     Input('client-store', 'data'),

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -1,5 +1,7 @@
 import io
 
+from components.step_title import StepTitle
+
 from app import app
 from dash import (
     Output,
@@ -150,11 +152,13 @@ def process_modal_error(list_of_contents, client_selected, filename, n_clicks, s
         raise PreventUpdate
 
 
-@app.callback(Output('icon-success-uploadfirst', 'children'),
-              Output('first-step-container', 'style'),
-              Input('complete-first-step-btn', 'n_clicks'),
-              prevent_initial_call=True,
-              allow_duplicate=True,)
+@app.callback(
+    Output(StepTitle.get_step_id('client-first'), 'children'),
+    Output('first-step-container', 'style'),
+    Input('complete-first-step-btn', 'n_clicks'),
+    prevent_initial_call=True,
+    allow_duplicate=True,
+)
 def mark_fist_step_as_completed(n_clicks):
     if not n_clicks:
         raise PreventUpdate

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -1,6 +1,5 @@
 import io
 
-from components.step_title import StepTitle
 
 from app import app
 from dash import (
@@ -21,9 +20,12 @@ from callbacks_helpers import (
     process_external_provider_data,
     process_client,
 )
-from components.download_area import DownloadButtonsArea
-from components.complete_step_btn import CompleteStepBtn
-from components.upload import Upload
+from components import (
+    CompleteStepBtn,
+    DownloadButtonsArea,
+    StepTitle,
+    Upload,
+    )
 from ids import (
     external_providers,
     osiris_accounts,

--- a/web-app/callback.py
+++ b/web-app/callback.py
@@ -22,6 +22,7 @@ from callbacks_helpers import (
     process_client,
 )
 from components.download_area import DownloadButtonsArea
+from components.complete_step_btn import CompleteStepBtn
 from components.upload import Upload
 from ids import (
     external_providers,
@@ -29,13 +30,15 @@ from ids import (
 )
 
 
-@app.callback(Output(DownloadButtonsArea.get_id("prepare"), 'children'),
-              Output('stored-dfs', 'data'),
-              Output('complete-first-step-btn', 'style'),
-              Input(Upload.get_upload_id('prepare-accounts'), 'contents'),
-              Input('client-store', 'data'),
-              prevent_initial_call=True,
-              allow_duplicate=True,)
+@app.callback(
+    Output(DownloadButtonsArea.get_id("prepare"), 'children'),
+    Output('stored-dfs', 'data'),
+    Output(CompleteStepBtn.get_btn_id('client-first'), 'style'),
+    Input(Upload.get_upload_id('prepare-accounts'), 'contents'),
+    Input('client-store', 'data'),
+    prevent_initial_call=True,
+    allow_duplicate=True,
+)
 def upload_csv(list_of_contents, client_selected):
 
     if list_of_contents and client_selected.get('selected_client'):
@@ -155,7 +158,7 @@ def process_modal_error(list_of_contents, client_selected, filename, n_clicks, s
 @app.callback(
     Output(StepTitle.get_step_id('client-first'), 'children'),
     Output('first-step-container', 'style'),
-    Input('complete-first-step-btn', 'n_clicks'),
+    Input(CompleteStepBtn.get_btn_id('client-first'), 'n_clicks'),
     prevent_initial_call=True,
     allow_duplicate=True,
 )

--- a/web-app/callbacks_helpers.py
+++ b/web-app/callbacks_helpers.py
@@ -10,7 +10,7 @@ from dash import (
 from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 
-from components.download_button import DownloadButton
+from components import DownloadButton
 from src.adapters.dash_dataframe_saver import DashDataFrameSaver
 from src.constants.constants import ACCOUNTS_MODEL_CSV_PATH
 from src.data_info import GenerateDataInfo

--- a/web-app/components/__init__.py
+++ b/web-app/components/__init__.py
@@ -1,0 +1,13 @@
+# flake8: noqa
+
+from .clear_data import ClearData
+from .client_button import ClientButton
+from .clients_dropdown import ClientsDropdown
+from .complete_step_btn import CompleteStepBtn
+from .download_area import DownloadButtonsArea
+from .download_button import DownloadButton
+from .external_data_providers_dropdown import ExternalDataProvidersDropDown
+from .step_title import StepTitle
+from .upload import Upload
+
+

--- a/web-app/components/__init__.py
+++ b/web-app/components/__init__.py
@@ -7,6 +7,7 @@ from .complete_step_btn import CompleteStepBtn
 from .download_area import DownloadButtonsArea
 from .download_button import DownloadButton
 from .external_data_providers_dropdown import ExternalDataProvidersDropDown
+from .filename_uploaded import FilenameUploaded
 from .step_title import StepTitle
 from .upload import Upload
 

--- a/web-app/components/complete_step_btn.py
+++ b/web-app/components/complete_step_btn.py
@@ -12,10 +12,10 @@ class CompleteStepBtn:
                 html.I(
                     className="fa-regular fa-circle-check",
                     style={"color": "white", 'marginLeft': '0.7rem', 'fontSize': 'x-large'},
-                    id="check-step-icon"
+                    id=cls.get_icon_id(id)
                 ),
             ],
-            id=id,
+            id=cls.get_btn_id(id),
             style={'display': 'none'}
         )
         return html.Div(
@@ -23,4 +23,10 @@ class CompleteStepBtn:
             className='completed-step-bnt-container'
         )
 
-        return btn
+    @staticmethod
+    def get_icon_id(id: str) -> str:
+        return f"check-step-icon-{id}"
+
+    @staticmethod
+    def get_btn_id(id: str) -> str:
+        return f"complete-step-btn-{id}"

--- a/web-app/components/complete_step_btn.py
+++ b/web-app/components/complete_step_btn.py
@@ -4,7 +4,7 @@ from dash import html
 class CompleteStepBtn:
 
     @classmethod
-    def create(self, id: str):
+    def create(cls, id: str):
 
         btn = html.Button(
             [

--- a/web-app/components/complete_step_btn.py
+++ b/web-app/components/complete_step_btn.py
@@ -18,5 +18,9 @@ class CompleteStepBtn:
             id=id,
             style={'display': 'none'}
         )
+        return html.Div(
+            btn,
+            className='completed-step-bnt-container'
+        )
 
         return btn

--- a/web-app/components/filename_uploaded.py
+++ b/web-app/components/filename_uploaded.py
@@ -1,0 +1,16 @@
+from dash import html
+
+
+class FilenameUploaded:
+
+    @classmethod
+    def create(cls, id: str) -> html.Div:
+        return html.Div(
+            id=cls.get_id(id),
+            style={'display': 'none'},
+            className='filaname-container'
+        )
+
+    @staticmethod
+    def get_id(id: str) -> dict:
+        return {'type': 'filename-uploaded', 'id': id}

--- a/web-app/components/step_title.py
+++ b/web-app/components/step_title.py
@@ -9,8 +9,12 @@ class StepTitle:
         title = html.Div([
             html.Img(src="assets/attach-icon.svg", height=20, style={'marginLeft': '5px'}),
             html.Span(title_step, className="attach-file",),
-            html.Span(id=f"icon-success-upload{step_id}"),
+            html.Span(id=cls.get_step_id(step_id)),
             html.Hr(style={"color": "black", "marginTop": "0"})
         ], className="step-title")
 
         return title
+
+    @staticmethod
+    def get_step_id(step_id: str) -> str:
+        return f"icon-success-upload-{step_id}"

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -40,7 +40,10 @@ app_layout = html.Div([
                             html.P("Selecciona un cliente", className="selec-client")
                         ]),
                         ClientsDropdown.create(),
-                        StepTitle.create(title_step="1. Subir archivo para preparación cuentas", step_id='first'),
+                        StepTitle.create(
+                            title_step="1. Subir archivo para preparación cuentas",
+                            step_id='client-first'
+                        ),
                         html.Div(
                             id="filename-uploaded-first-step",
                             style={'display': 'none'},

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -7,6 +7,7 @@ from components import (
     CompleteStepBtn,
     DownloadButtonsArea,
     ExternalDataProvidersDropDown,
+    FilenameUploaded,
     StepTitle,
     Upload,
 )
@@ -46,11 +47,7 @@ app_layout = html.Div([
                             title_step="1. Subir archivo para preparación cuentas",
                             step_id='client-first'
                         ),
-                        html.Div(
-                            id="filename-uploaded-first-step",
-                            style={'display': 'none'},
-                            className='filaname-container'
-                        ),
+                        FilenameUploaded.create('client-first-step'),
                         html.Div([
                             Upload.create(
                                 id="prepare-accounts",

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -56,7 +56,7 @@ app_layout = html.Div([
                                 upload_disabled=False,
                             ),
                             DownloadButtonsArea.create("prepare"),
-                            CompleteStepBtn.create(id='complete-first-step-btn'),
+                            CompleteStepBtn.create(id='client-first'),
 
                         ], id='first-step-container'),
                         dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -115,7 +115,7 @@ app_layout = html.Div([
                             )
                         ]),
                         DownloadButtonsArea.create("prepare-external-data-provider"),
-                        dcc.Store(id='store-data-provider', data={}, clear_data=False, storage_type='session')
+                        dcc.Store(id='store-data-provider', data={}, clear_data=False, storage_type='memory')
                     ],
                     id="tab_data_providers",
                     tab_id="tab_data_providers",

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -56,11 +56,8 @@ app_layout = html.Div([
                                 upload_disabled=False,
                             ),
                             DownloadButtonsArea.create("prepare"),
-                            html.Div([
-                                CompleteStepBtn.create(id='complete-first-step-btn')
-                                ],
-                                className='completed-step-bnt-container'
-                            ),
+                            CompleteStepBtn.create(id='complete-first-step-btn'),
+
                         ], id='first-step-container'),
                         dcc.Store(id='stored-dfs', clear_data=False, storage_type='memory'),
                         dcc.Store(

--- a/web-app/layout.py
+++ b/web-app/layout.py
@@ -1,13 +1,15 @@
 from dash import html, dcc
 import dash_bootstrap_components as dbc
 
-from components.clear_data import ClearData
-from components.download_area import DownloadButtonsArea
-from components.upload import Upload
-from components.step_title import StepTitle
-from components.complete_step_btn import CompleteStepBtn
-from components.clients_dropdown import ClientsDropdown
-from components.external_data_providers_dropdown import ExternalDataProvidersDropDown
+from components import (
+    ClearData,
+    ClientsDropdown,
+    CompleteStepBtn,
+    DownloadButtonsArea,
+    ExternalDataProvidersDropDown,
+    StepTitle,
+    Upload,
+)
 from ids import (
     osiris_accounts,
     external_providers,


### PR DESCRIPTION
add several improvements to the `web-app` (frontend in dash). Each of the are wrapped in atomics commits:

- web-app: components: add get_step_id to StepTitlte
- web-app: change to memory type to external provider store
- web-app: CompleteStepBtn: change self for cls
- web-app: CompleteStepBtn: add html.Div wrappper in create method
- web-app: CompleteStepBtn: add get ids methods and refactor 
- web-app: components: add every components to init to improve imports
- web-app: components: create FilenameUploaded to reuse it

These changes are necessary to be able to reuse them in the external provider tab.